### PR TITLE
Add Gmail inbox labeler using local Ollama

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,10 @@ ENV/
 .env.local
 .env.*.local
 
+# Gmail OAuth secrets/tokens
+credentials.json
+token.json
+
 # Testing
 .pytest_cache/
 .coverage

--- a/projects/04-gmail-inbox-labeler/.env.example
+++ b/projects/04-gmail-inbox-labeler/.env.example
@@ -1,0 +1,10 @@
+# Path to the OAuth client secret downloaded from Google Cloud Console
+# (APIs & Services > Credentials > OAuth client ID > Desktop app)
+GMAIL_CREDENTIALS_PATH=credentials.json
+
+# Where the authorized user token is cached after the first interactive login
+GMAIL_TOKEN_PATH=token.json
+
+# Local Ollama server
+OLLAMA_HOST=http://localhost:11434
+OLLAMA_MODEL=llama3

--- a/projects/04-gmail-inbox-labeler/README.md
+++ b/projects/04-gmail-inbox-labeler/README.md
@@ -1,0 +1,73 @@
+# Gmail Inbox Labeler
+
+Moves messages out of a Gmail inbox into one or more existing labels, using a
+**local Ollama model** to decide which label(s) each message belongs to. No
+email content is ever sent to a hosted/cloud LLM.
+
+## How it works
+
+1. Authenticates to the Gmail API (OAuth2, `gmail.modify` scope).
+2. Lists the user's existing labels (these become the classifier's choices —
+   create the labels you want in Gmail first).
+3. For each message currently in the inbox, sends the subject/sender/snippet
+   to a local Ollama model and asks it to pick zero, one, or several of the
+   existing labels.
+4. Applies the chosen label(s) and removes `INBOX`, so the message moves out
+   of the inbox. Messages the model doesn't confidently match to any label
+   are left alone.
+
+Re-running the script is safe: it only ever queries `in:inbox` (or a custom
+`--query`), so messages already moved out of the inbox aren't touched again.
+
+## Setup
+
+1. Install dependencies:
+   ```bash
+   pip install -r requirements.txt
+   ```
+2. Create a Gmail OAuth client: Google Cloud Console → APIs & Services →
+   Credentials → Create Credentials → OAuth client ID → Desktop app. Download
+   the JSON and save it as `credentials.json` in this folder (or point
+   `GMAIL_CREDENTIALS_PATH` elsewhere).
+3. Make sure [Ollama](https://ollama.com) is running locally with a model
+   pulled, e.g.:
+   ```bash
+   ollama pull llama3
+   ollama serve
+   ```
+4. Copy `.env.example` to `.env` and adjust as needed.
+
+The first run opens a browser window for the Gmail OAuth consent screen and
+caches the resulting token at `GMAIL_TOKEN_PATH` (default `token.json`) so
+subsequent runs are non-interactive.
+
+`credentials.json` and `token.json` contain secrets — never commit them
+(already covered by `.gitignore`).
+
+## Usage
+
+Preview what the script would do without changing anything:
+```bash
+python label_inbox.py --dry-run
+```
+
+Actually move messages:
+```bash
+python label_inbox.py
+```
+
+Useful flags:
+| Flag | Default | Description |
+|---|---|---|
+| `--query` | `in:inbox` | Gmail search query selecting which messages to process |
+| `--max-results` | `100` | Max messages to process in one run |
+| `--model` | `llama3` (or `OLLAMA_MODEL`) | Local Ollama model to use |
+| `--ollama-host` | `http://localhost:11434` (or `OLLAMA_HOST`) | Local Ollama server URL |
+| `--dry-run` | off | Log decisions without modifying any message |
+| `--verbose` | off | Enable debug logging |
+
+## Tests
+
+```bash
+python -m pytest tests/ -v
+```

--- a/projects/04-gmail-inbox-labeler/gmail_auth.py
+++ b/projects/04-gmail-inbox-labeler/gmail_auth.py
@@ -1,0 +1,45 @@
+#!/usr/bin/env python3
+"""OAuth2 authentication and Gmail API service construction."""
+import os
+
+from google.auth.transport.requests import Request
+from google.oauth2.credentials import Credentials
+from google_auth_oauthlib.flow import InstalledAppFlow
+from googleapiclient.discovery import build
+
+# gmail.modify covers reading, labeling, and archiving (removing INBOX) but
+# not permanent deletion.
+SCOPES = ["https://www.googleapis.com/auth/gmail.modify"]
+
+
+def load_credentials(credentials_path: str, token_path: str) -> Credentials:
+    """Return valid user credentials, running the interactive OAuth flow
+    the first time and refreshing/caching the token on subsequent calls."""
+    creds = None
+    if os.path.exists(token_path):
+        creds = Credentials.from_authorized_user_file(token_path, SCOPES)
+
+    if not creds or not creds.valid:
+        if creds and creds.expired and creds.refresh_token:
+            creds.refresh(Request())
+        else:
+            if not os.path.exists(credentials_path):
+                raise FileNotFoundError(
+                    f"Gmail OAuth client secret not found at '{credentials_path}'. "
+                    "Download one from Google Cloud Console (APIs & Services > "
+                    "Credentials > OAuth client ID > Desktop app) and set "
+                    "GMAIL_CREDENTIALS_PATH."
+                )
+            flow = InstalledAppFlow.from_client_secrets_file(credentials_path, SCOPES)
+            creds = flow.run_local_server(port=0)
+
+        with open(token_path, "w") as token_file:
+            token_file.write(creds.to_json())
+
+    return creds
+
+
+def get_gmail_service(credentials_path: str, token_path: str):
+    """Build an authorized Gmail API client."""
+    creds = load_credentials(credentials_path, token_path)
+    return build("gmail", "v1", credentials=creds)

--- a/projects/04-gmail-inbox-labeler/label_inbox.py
+++ b/projects/04-gmail-inbox-labeler/label_inbox.py
@@ -1,0 +1,218 @@
+#!/usr/bin/env python3
+"""Move Gmail inbox messages into one or more chosen labels, classified by a
+local Ollama model.
+
+Usage:
+    python label_inbox.py --dry-run
+    python label_inbox.py --max-results 50
+"""
+import argparse
+import logging
+import os
+from pathlib import Path
+
+from gmail_auth import get_gmail_service
+from ollama_classifier import (
+    DEFAULT_HOST,
+    DEFAULT_MODEL,
+    OllamaConnectionError,
+    classify_email,
+)
+
+logger = logging.getLogger("label_inbox")
+
+
+def load_env():
+    """Load environment variables from a .env file next to this script."""
+    env_path = Path(__file__).parent / ".env"
+    if not env_path.exists():
+        return
+    with open(env_path) as f:
+        for line in f:
+            line = line.strip()
+            if line and not line.startswith("#") and "=" in line:
+                key, value = line.split("=", 1)
+                os.environ.setdefault(key.strip(), value.strip())
+
+
+def get_user_labels(service) -> dict:
+    """Return {label_name: label_id} for the user's own (non-system) labels."""
+    response = service.users().labels().list(userId="me").execute()
+    return {
+        label["name"]: label["id"]
+        for label in response.get("labels", [])
+        if label.get("type") == "user"
+    }
+
+
+def get_message_summary(service, message_id: str) -> dict:
+    """Fetch just the headers/snippet needed for classification."""
+    message = (
+        service.users()
+        .messages()
+        .get(
+            userId="me",
+            id=message_id,
+            format="metadata",
+            metadataHeaders=["From", "Subject"],
+        )
+        .execute()
+    )
+    headers = {h["name"]: h["value"] for h in message["payload"].get("headers", [])}
+    return {
+        "id": message_id,
+        "subject": headers.get("Subject", "(no subject)"),
+        "sender": headers.get("From", "(unknown sender)"),
+        "snippet": message.get("snippet", ""),
+    }
+
+
+def list_inbox_message_ids(service, query: str, max_results: int) -> list[str]:
+    ids = []
+    request = service.users().messages().list(
+        userId="me", q=query, maxResults=min(max_results, 500)
+    )
+    while request is not None and len(ids) < max_results:
+        response = request.execute()
+        ids.extend(m["id"] for m in response.get("messages", []))
+        request = service.users().messages().list_next(request, response)
+    return ids[:max_results]
+
+
+def apply_labels(service, message_id: str, label_ids: list[str]) -> None:
+    service.users().messages().modify(
+        userId="me",
+        id=message_id,
+        body={"addLabelIds": label_ids, "removeLabelIds": ["INBOX"]},
+    ).execute()
+
+
+def run(
+    query: str,
+    max_results: int,
+    dry_run: bool,
+    model: str,
+    ollama_host: str,
+    credentials_path: str,
+    token_path: str,
+) -> None:
+    service = get_gmail_service(credentials_path, token_path)
+
+    label_name_to_id = get_user_labels(service)
+    if not label_name_to_id:
+        logger.warning("No user labels found in this Gmail account. Nothing to classify into.")
+        return
+    label_names = list(label_name_to_id.keys())
+
+    message_ids = list_inbox_message_ids(service, query, max_results)
+    logger.info("Found %d inbox message(s) matching query '%s'", len(message_ids), query)
+
+    for message_id in message_ids:
+        summary = get_message_summary(service, message_id)
+
+        try:
+            chosen_labels = classify_email(
+                subject=summary["subject"],
+                sender=summary["sender"],
+                snippet=summary["snippet"],
+                labels=label_names,
+                model=model,
+                host=ollama_host,
+            )
+        except OllamaConnectionError as exc:
+            logger.error("Skipping message %s: %s", message_id, exc)
+            continue
+
+        if not chosen_labels:
+            logger.info(
+                "SKIP  %s | %s -> no matching label, left in inbox",
+                message_id,
+                summary["subject"],
+            )
+            continue
+
+        label_ids = [label_name_to_id[name] for name in chosen_labels]
+
+        if dry_run:
+            logger.info(
+                "DRY-RUN  %s | %s -> would apply %s and remove from inbox",
+                message_id,
+                summary["subject"],
+                chosen_labels,
+            )
+        else:
+            apply_labels(service, message_id, label_ids)
+            logger.info(
+                "MOVED  %s | %s -> %s",
+                message_id,
+                summary["subject"],
+                chosen_labels,
+            )
+
+
+def parse_args(argv=None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--query",
+        default="in:inbox",
+        help="Gmail search query selecting which messages to process (default: in:inbox)",
+    )
+    parser.add_argument(
+        "--max-results",
+        type=int,
+        default=100,
+        help="Maximum number of messages to process in one run (default: 100)",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Log the label decisions without modifying any message",
+    )
+    parser.add_argument(
+        "--model",
+        default=os.getenv("OLLAMA_MODEL", DEFAULT_MODEL),
+        help="Local Ollama model to use for classification",
+    )
+    parser.add_argument(
+        "--ollama-host",
+        default=os.getenv("OLLAMA_HOST", DEFAULT_HOST),
+        help="Local Ollama server URL",
+    )
+    parser.add_argument(
+        "--credentials",
+        default=os.getenv("GMAIL_CREDENTIALS_PATH", "credentials.json"),
+        help="Path to the Gmail OAuth client secret JSON",
+    )
+    parser.add_argument(
+        "--token",
+        default=os.getenv("GMAIL_TOKEN_PATH", "token.json"),
+        help="Path where the authorized user token is cached",
+    )
+    parser.add_argument(
+        "--verbose",
+        action="store_true",
+        help="Enable debug logging",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv=None) -> None:
+    load_env()
+    args = parse_args(argv)
+    logging.basicConfig(
+        level=logging.DEBUG if args.verbose else logging.INFO,
+        format="%(asctime)s %(levelname)s %(message)s",
+    )
+    run(
+        query=args.query,
+        max_results=args.max_results,
+        dry_run=args.dry_run,
+        model=args.model,
+        ollama_host=args.ollama_host,
+        credentials_path=args.credentials,
+        token_path=args.token,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/projects/04-gmail-inbox-labeler/ollama_classifier.py
+++ b/projects/04-gmail-inbox-labeler/ollama_classifier.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""Classify an email into zero or more existing Gmail labels using a local
+Ollama model. No email content is ever sent to a hosted/cloud LLM."""
+import json
+
+import requests
+
+DEFAULT_HOST = "http://localhost:11434"
+DEFAULT_MODEL = "llama3"
+DEFAULT_TIMEOUT = 60
+
+_PROMPT_TEMPLATE = """You are an email triage assistant. Choose which of the
+following labels this email belongs to. You may choose zero, one, or several
+labels. Only choose from the exact label names listed below - never invent a
+new label.
+
+Available labels:
+{labels}
+
+Email:
+From: {sender}
+Subject: {subject}
+Snippet: {snippet}
+
+Respond with ONLY a JSON array of the chosen label names, e.g. ["Work"] or
+["Work", "Urgent"] or [] if none apply. Do not include any other text.
+"""
+
+
+class OllamaConnectionError(RuntimeError):
+    """Raised when the local Ollama server can't be reached."""
+
+
+def _build_prompt(subject: str, sender: str, snippet: str, labels: list[str]) -> str:
+    label_list = "\n".join(f"- {label}" for label in labels)
+    return _PROMPT_TEMPLATE.format(
+        labels=label_list, sender=sender, subject=subject, snippet=snippet
+    )
+
+
+def _parse_labels(raw_text: str, valid_labels: list[str]) -> list[str]:
+    """Parse the model's JSON array response and keep only labels that
+    exactly match (case-insensitively) one of the known valid labels."""
+    lookup = {label.lower(): label for label in valid_labels}
+    try:
+        parsed = json.loads(raw_text.strip())
+    except json.JSONDecodeError:
+        return []
+
+    if not isinstance(parsed, list):
+        return []
+
+    chosen = []
+    for item in parsed:
+        if not isinstance(item, str):
+            continue
+        match = lookup.get(item.strip().lower())
+        if match and match not in chosen:
+            chosen.append(match)
+    return chosen
+
+
+def classify_email(
+    subject: str,
+    sender: str,
+    snippet: str,
+    labels: list[str],
+    model: str = DEFAULT_MODEL,
+    host: str = DEFAULT_HOST,
+    timeout: int = DEFAULT_TIMEOUT,
+) -> list[str]:
+    """Return the subset of `labels` the local Ollama model assigns to this
+    email. Returns an empty list if no label applies."""
+    if not labels:
+        return []
+
+    prompt = _build_prompt(subject, sender, snippet, labels)
+
+    try:
+        response = requests.post(
+            f"{host.rstrip('/')}/api/generate",
+            json={
+                "model": model,
+                "prompt": prompt,
+                "stream": False,
+                "format": "json",
+            },
+            timeout=timeout,
+        )
+        response.raise_for_status()
+    except requests.exceptions.ConnectionError as exc:
+        raise OllamaConnectionError(
+            f"Could not reach local Ollama server at {host}. "
+            "Is `ollama serve` running?"
+        ) from exc
+    except requests.exceptions.RequestException as exc:
+        raise OllamaConnectionError(f"Ollama request failed: {exc}") from exc
+
+    raw_text = response.json().get("response", "")
+    return _parse_labels(raw_text, labels)

--- a/projects/04-gmail-inbox-labeler/requirements.txt
+++ b/projects/04-gmail-inbox-labeler/requirements.txt
@@ -1,0 +1,4 @@
+google-api-python-client>=2.100.0
+google-auth-httplib2>=0.2.0
+google-auth-oauthlib>=1.2.0
+requests>=2.31.0

--- a/projects/04-gmail-inbox-labeler/tests/test_label_inbox.py
+++ b/projects/04-gmail-inbox-labeler/tests/test_label_inbox.py
@@ -1,0 +1,206 @@
+import sys
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from label_inbox import (
+    apply_labels,
+    get_message_summary,
+    get_user_labels,
+    list_inbox_message_ids,
+    run,
+)
+
+
+def make_service():
+    return MagicMock()
+
+
+class TestGetUserLabels:
+    def test_filters_to_user_labels_only(self):
+        service = make_service()
+        service.users().labels().list().execute.return_value = {
+            "labels": [
+                {"id": "l1", "name": "Work", "type": "user"},
+                {"id": "INBOX", "name": "INBOX", "type": "system"},
+                {"id": "l2", "name": "Personal", "type": "user"},
+            ]
+        }
+        result = get_user_labels(service)
+        assert result == {"Work": "l1", "Personal": "l2"}
+
+
+class TestGetMessageSummary:
+    def test_extracts_headers_and_snippet(self):
+        service = make_service()
+        service.users().messages().get().execute.return_value = {
+            "payload": {
+                "headers": [
+                    {"name": "From", "value": "boss@company.com"},
+                    {"name": "Subject", "value": "Meeting"},
+                ]
+            },
+            "snippet": "Let's sync",
+        }
+        result = get_message_summary(service, "msg1")
+        assert result == {
+            "id": "msg1",
+            "subject": "Meeting",
+            "sender": "boss@company.com",
+            "snippet": "Let's sync",
+        }
+
+    def test_missing_headers_use_defaults(self):
+        service = make_service()
+        service.users().messages().get().execute.return_value = {
+            "payload": {"headers": []},
+            "snippet": "",
+        }
+        result = get_message_summary(service, "msg1")
+        assert result["subject"] == "(no subject)"
+        assert result["sender"] == "(unknown sender)"
+
+
+class TestListInboxMessageIds:
+    def test_paginates_until_max_results(self):
+        service = make_service()
+        list_calls = service.users().messages().list
+        list_next = service.users().messages().list_next
+
+        first_page = {"messages": [{"id": "a"}, {"id": "b"}]}
+        second_page = {"messages": [{"id": "c"}]}
+        list_calls.return_value.execute.side_effect = [first_page, second_page]
+        list_next.side_effect = [list_calls.return_value, None]
+
+        result = list_inbox_message_ids(service, "in:inbox", max_results=10)
+        assert result == ["a", "b", "c"]
+
+    def test_stops_early_once_max_results_reached(self):
+        service = make_service()
+        service.users().messages().list.return_value.execute.return_value = {
+            "messages": [{"id": "a"}, {"id": "b"}, {"id": "c"}]
+        }
+        result = list_inbox_message_ids(service, "in:inbox", max_results=2)
+        assert result == ["a", "b"]
+
+
+class TestApplyLabels:
+    def test_adds_labels_and_removes_inbox(self):
+        service = make_service()
+        apply_labels(service, "msg1", ["l1", "l2"])
+        service.users().messages().modify.assert_called_with(
+            userId="me",
+            id="msg1",
+            body={"addLabelIds": ["l1", "l2"], "removeLabelIds": ["INBOX"]},
+        )
+
+
+class TestRun:
+    def _service_with_labels_and_messages(self, labels, message_ids):
+        service = make_service()
+        service.users().labels().list().execute.return_value = {"labels": labels}
+        service.users().messages().list().execute.return_value = {
+            "messages": [{"id": mid} for mid in message_ids]
+        }
+        service.users().messages().list_next.return_value = None
+        return service
+
+    @patch("label_inbox.get_gmail_service")
+    @patch("label_inbox.classify_email")
+    def test_dry_run_never_calls_modify(self, mock_classify, mock_get_service):
+        service = self._service_with_labels_and_messages(
+            labels=[{"id": "l1", "name": "Work", "type": "user"}],
+            message_ids=["m1"],
+        )
+        service.users().messages().get().execute.return_value = {
+            "payload": {"headers": []},
+            "snippet": "",
+        }
+        mock_get_service.return_value = service
+        mock_classify.return_value = ["Work"]
+
+        run(
+            query="in:inbox",
+            max_results=10,
+            dry_run=True,
+            model="llama3",
+            ollama_host="http://localhost:11434",
+            credentials_path="credentials.json",
+            token_path="token.json",
+        )
+
+        service.users().messages().modify.assert_not_called()
+
+    @patch("label_inbox.get_gmail_service")
+    @patch("label_inbox.classify_email")
+    def test_applies_labels_when_not_dry_run(self, mock_classify, mock_get_service):
+        service = self._service_with_labels_and_messages(
+            labels=[{"id": "l1", "name": "Work", "type": "user"}],
+            message_ids=["m1"],
+        )
+        service.users().messages().get().execute.return_value = {
+            "payload": {"headers": []},
+            "snippet": "",
+        }
+        mock_get_service.return_value = service
+        mock_classify.return_value = ["Work"]
+
+        run(
+            query="in:inbox",
+            max_results=10,
+            dry_run=False,
+            model="llama3",
+            ollama_host="http://localhost:11434",
+            credentials_path="credentials.json",
+            token_path="token.json",
+        )
+
+        service.users().messages().modify.assert_called_with(
+            userId="me",
+            id="m1",
+            body={"addLabelIds": ["l1"], "removeLabelIds": ["INBOX"]},
+        )
+
+    @patch("label_inbox.get_gmail_service")
+    @patch("label_inbox.classify_email")
+    def test_no_matching_label_skips_message(self, mock_classify, mock_get_service):
+        service = self._service_with_labels_and_messages(
+            labels=[{"id": "l1", "name": "Work", "type": "user"}],
+            message_ids=["m1"],
+        )
+        service.users().messages().get().execute.return_value = {
+            "payload": {"headers": []},
+            "snippet": "",
+        }
+        mock_get_service.return_value = service
+        mock_classify.return_value = []
+
+        run(
+            query="in:inbox",
+            max_results=10,
+            dry_run=False,
+            model="llama3",
+            ollama_host="http://localhost:11434",
+            credentials_path="credentials.json",
+            token_path="token.json",
+        )
+
+        service.users().messages().modify.assert_not_called()
+
+    @patch("label_inbox.get_gmail_service")
+    def test_no_user_labels_exits_without_listing_messages(self, mock_get_service):
+        service = self._service_with_labels_and_messages(labels=[], message_ids=[])
+        mock_get_service.return_value = service
+
+        run(
+            query="in:inbox",
+            max_results=10,
+            dry_run=False,
+            model="llama3",
+            ollama_host="http://localhost:11434",
+            credentials_path="credentials.json",
+            token_path="token.json",
+        )
+
+        service.users().messages().list().execute.assert_not_called()

--- a/projects/04-gmail-inbox-labeler/tests/test_ollama_classifier.py
+++ b/projects/04-gmail-inbox-labeler/tests/test_ollama_classifier.py
@@ -1,0 +1,89 @@
+import json
+import sys
+from pathlib import Path
+from unittest.mock import Mock, patch
+
+import pytest
+import requests
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from ollama_classifier import OllamaConnectionError, _parse_labels, classify_email
+
+
+class TestParseLabels:
+    def test_exact_match(self):
+        assert _parse_labels('["Work"]', ["Work", "Personal"]) == ["Work"]
+
+    def test_case_insensitive_match_returns_canonical_name(self):
+        assert _parse_labels('["work"]', ["Work", "Personal"]) == ["Work"]
+
+    def test_multiple_labels(self):
+        result = _parse_labels('["Work", "Urgent"]', ["Work", "Urgent", "Personal"])
+        assert result == ["Work", "Urgent"]
+
+    def test_unknown_label_is_dropped(self):
+        assert _parse_labels('["Spam"]', ["Work", "Personal"]) == []
+
+    def test_empty_array_means_no_label(self):
+        assert _parse_labels("[]", ["Work"]) == []
+
+    def test_malformed_json_returns_empty(self):
+        assert _parse_labels("not json", ["Work"]) == []
+
+    def test_non_array_json_returns_empty(self):
+        assert _parse_labels('{"label": "Work"}', ["Work"]) == []
+
+    def test_duplicates_are_deduped(self):
+        assert _parse_labels('["Work", "work"]', ["Work"]) == ["Work"]
+
+
+class TestClassifyEmail:
+    def test_no_labels_available_returns_empty_without_network_call(self):
+        with patch("ollama_classifier.requests.post") as mock_post:
+            result = classify_email("Subj", "a@b.com", "snippet", labels=[])
+        assert result == []
+        mock_post.assert_not_called()
+
+    def test_calls_local_ollama_and_parses_response(self):
+        mock_response = Mock()
+        mock_response.json.return_value = {"response": '["Work"]'}
+        mock_response.raise_for_status = Mock()
+
+        with patch("ollama_classifier.requests.post", return_value=mock_response) as mock_post:
+            result = classify_email(
+                "Meeting notes",
+                "boss@company.com",
+                "Let's sync tomorrow",
+                labels=["Work", "Personal"],
+                model="llama3",
+                host="http://localhost:11434",
+            )
+
+        assert result == ["Work"]
+        called_url = mock_post.call_args.args[0]
+        assert called_url == "http://localhost:11434/api/generate"
+        payload = mock_post.call_args.kwargs["json"]
+        assert payload["model"] == "llama3"
+        assert "Work" in payload["prompt"]
+        assert "Personal" in payload["prompt"]
+
+    def test_connection_error_raises_ollama_connection_error(self):
+        with patch(
+            "ollama_classifier.requests.post",
+            side_effect=requests.exceptions.ConnectionError(),
+        ):
+            with pytest.raises(OllamaConnectionError):
+                classify_email("Subj", "a@b.com", "snippet", labels=["Work"])
+
+    def test_strips_trailing_slash_from_host(self):
+        mock_response = Mock()
+        mock_response.json.return_value = {"response": "[]"}
+        mock_response.raise_for_status = Mock()
+
+        with patch("ollama_classifier.requests.post", return_value=mock_response) as mock_post:
+            classify_email(
+                "Subj", "a@b.com", "snippet", labels=["Work"], host="http://localhost:11434/"
+            )
+
+        assert mock_post.call_args.args[0] == "http://localhost:11434/api/generate"


### PR DESCRIPTION
## Summary
- New `projects/04-gmail-inbox-labeler/` script that moves Gmail inbox messages into one or more existing labels
- Classification is done entirely by a **local Ollama model** (no cloud LLM calls) — the model picks zero or more of the account's existing labels per message based on subject/sender/snippet
- Applies the chosen label(s) and removes `INBOX`; supports `--dry-run` to preview without modifying anything; safe to re-run since it only ever queries `in:inbox`

## Files
- `gmail_auth.py` — OAuth2 flow / Gmail API service builder (`gmail.modify` scope)
- `ollama_classifier.py` — builds the classification prompt, calls the local Ollama `/api/generate` endpoint, validates the returned labels against the account's real label list
- `label_inbox.py` — CLI entry point (`--query`, `--max-results`, `--model`, `--ollama-host`, `--dry-run`, `--verbose`)
- `README.md` — setup (OAuth client, Ollama) and usage
- `tests/` — 22 unit tests covering label parsing, classification, pagination, dry-run vs. live modify, and the no-labels-available edge case

## Test plan
- [x] `python -m pytest tests/ -v` — 22/22 passing
- [x] `python -m py_compile` on all new modules
- [ ] Manual end-to-end run against a real Gmail inbox with Ollama running locally (needs OAuth client + pulled model, not doable in this environment)

Closes #3


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added a Gmail inbox labeling tool that classifies messages using a locally hosted Ollama model.
  - Supports existing Gmail labels, configurable searches, processing limits, verbose logging, and dry-run previews.
  - Applies selected labels and removes messages from the inbox when processing is enabled.
  - Added Gmail OAuth authentication with cached credentials and token refresh.

- **Documentation**
  - Added setup, configuration, usage, and testing guidance, including environment variable examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->