### PR TITLE
Fix gmail labeler label scope and non-determinism

### DIFF
--- a/projects/04-gmail-inbox-labeler/label_inbox.py
+++ b/projects/04-gmail-inbox-labeler/label_inbox.py
@@ -95,6 +95,7 @@ def run(
     ollama_host: str,
     credentials_path: str,
     token_path: str,
+    target_labels: list[str] | None = None,
 ) -> None:
     service = get_gmail_service(credentials_path, token_path)
 
@@ -102,7 +103,21 @@ def run(
     if not label_name_to_id:
         logger.warning("No user labels found in this Gmail account. Nothing to classify into.")
         return
-    label_names = list(label_name_to_id.keys())
+
+    if target_labels:
+        lookup = {name.lower(): name for name in label_name_to_id}
+        label_names = []
+        for wanted in target_labels:
+            match = lookup.get(wanted.strip().lower())
+            if not match:
+                logger.warning("Requested label '%s' not found in Gmail account; ignoring.", wanted)
+                continue
+            label_names.append(match)
+        if not label_names:
+            logger.error("None of the requested --labels matched an existing Gmail label. Aborting.")
+            return
+    else:
+        label_names = list(label_name_to_id.keys())
 
     message_ids = list_inbox_message_ids(service, query, max_results)
     logger.info("Found %d inbox message(s) matching query '%s'", len(message_ids), query)
@@ -169,6 +184,15 @@ def parse_args(argv=None) -> argparse.Namespace:
         help="Log the label decisions without modifying any message",
     )
     parser.add_argument(
+        "--labels",
+        default=os.getenv("GMAIL_TARGET_LABELS", ""),
+        help=(
+            "Comma-separated list of existing Gmail labels to restrict classification to "
+            "(e.g. 'Finances/Job Hunt'). If omitted, every user label in the account is "
+            "offered to the model as a candidate."
+        ),
+    )
+    parser.add_argument(
         "--model",
         default=os.getenv("OLLAMA_MODEL", DEFAULT_MODEL),
         help="Local Ollama model to use for classification",
@@ -203,6 +227,7 @@ def main(argv=None) -> None:
         level=logging.DEBUG if args.verbose else logging.INFO,
         format="%(asctime)s %(levelname)s %(message)s",
     )
+    target_labels = [name for name in args.labels.split(",") if name.strip()]
     run(
         query=args.query,
         max_results=args.max_results,
@@ -211,6 +236,7 @@ def main(argv=None) -> None:
         ollama_host=args.ollama_host,
         credentials_path=args.credentials,
         token_path=args.token,
+        target_labels=target_labels or None,
     )
 
 

--- a/projects/04-gmail-inbox-labeler/ollama_classifier.py
+++ b/projects/04-gmail-inbox-labeler/ollama_classifier.py
@@ -18,6 +18,14 @@ Rules:
 - Only add a second label if the email genuinely belongs in both.
 - If you are not confident any label clearly applies, return an empty list.
   Leaving an email unlabeled is better than guessing.
+- Label names may include a folder path (e.g. "Finances/Job Hunt") purely for
+  organizational purposes. Do NOT match on individual words in that path
+  (e.g. "Finances", "Personal"). Judge relevance only from the label's full,
+  specific meaning and the actual email content below. For example,
+  "Finances/Job Hunt" means recruiter outreach, job postings, job-search
+  alerts, or application/interview updates - it does NOT mean general
+  finance news, bills, stock-market updates, cashback, or shopping offers,
+  even though the word "Finances" appears in the path.
 
 Available labels:
 {labels}
@@ -108,6 +116,7 @@ def classify_email(
                 "prompt": prompt,
                 "stream": False,
                 "format": _response_schema(labels),
+                "options": {"temperature": 0},
             },
             timeout=timeout,
         )


### PR DESCRIPTION
## Summary
- Add `--labels`/`GMAIL_TARGET_LABELS` so the classifier only chooses among caller-specified labels instead of every label in the account.
- Pin Ollama request temperature to 0 for deterministic classification.
- Clarify the prompt so folder-path words (e.g. "Finances") aren't mistaken for label criteria, which was causing finance-news/bill/cashback emails to be mislabeled as job hunt.

Closes #17

## Test plan
- [ ] `python label_inbox.py --dry-run --labels "Finances/Job Hunt"` only ever proposes that label or none
- [ ] Re-running against the same messages produces identical dry-run decisions
- [ ] Finance-news/bill/cashback emails are no longer labeled Job Hunt

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an option to restrict inbox labeling to selected Gmail labels.
  * Labels can be provided through the command line or environment configuration.

* **Bug Fixes**
  * Improved classification for labels containing folder paths.
  * Increased consistency of automated label recommendations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->