### PR TITLE
Add scheduled Octopus Agile free-energy alerts

### DIFF
--- a/.github/workflows/octopus-agile-alert.yml
+++ b/.github/workflows/octopus-agile-alert.yml
@@ -1,0 +1,27 @@
+name: Octopus Agile price alert
+
+on:
+  schedule:
+    - cron: "30 16 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  check-rates:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+      - name: Check tomorrow's Agile rates
+        env:
+          ALERT_WEBHOOK_URL: ${{ secrets.ALERT_WEBHOOK_URL }}
+          OCTOPUS_PRODUCT_CODE: ${{ vars.OCTOPUS_PRODUCT_CODE }}
+          OCTOPUS_REGION: ${{ vars.OCTOPUS_REGION }}
+          OCTOPUS_TARIFF_CODE: ${{ vars.OCTOPUS_TARIFF_CODE }}
+          ALERT_THRESHOLD_PENCE: ${{ vars.ALERT_THRESHOLD_PENCE }}
+          ALERT_TIMEZONE: ${{ vars.ALERT_TIMEZONE }}
+        run: python projects/06-octopus-agile-alert/agile_alert.py

--- a/projects/06-octopus-agile-alert/README.md
+++ b/projects/06-octopus-agile-alert/README.md
@@ -1,0 +1,24 @@
+# Octopus Agile free-electricity alert
+
+This zero-dependency Python job checks tomorrow's half-hourly Octopus Agile prices and sends a webhook when any inclusive-of-VAT rate is at or below a configurable threshold.
+
+## Configuration
+
+| Variable | Default | Purpose |
+| --- | --- | --- |
+| `OCTOPUS_PRODUCT_CODE` | `AGILE-24-10-01` | Agile product code |
+| `OCTOPUS_REGION` | `C` | GSP/region suffix used to derive the tariff code |
+| `OCTOPUS_TARIFF_CODE` | `E-1R-<product>-<region>` | Optional full tariff-code override |
+| `ALERT_WEBHOOK_URL` | none | Slack-compatible incoming webhook URL |
+| `ALERT_THRESHOLD_PENCE` | `0` | Alert threshold in pence/kWh (use `5` for very-cheap alerts) |
+| `ALERT_TIMEZONE` | `Europe/London` | Timezone used to define and display tomorrow |
+
+Run a read-only check locally:
+
+```bash
+python projects/06-octopus-agile-alert/agile_alert.py --dry-run
+```
+
+The included GitHub Actions workflow runs daily at 16:30 UTC, after the usual publication time, and can also be dispatched manually. Add an `ALERT_WEBHOOK_URL` repository secret and, if required, repository variables for the other settings. When no qualifying slot exists, the job remains silent apart from its action log. API or webhook failures make the job fail rather than silently losing an alert.
+
+The webhook body is `{"text": "..."}`, which works directly with Slack incoming webhooks and can be adapted by a generic webhook relay for email or push notifications.

--- a/projects/06-octopus-agile-alert/agile_alert.py
+++ b/projects/06-octopus-agile-alert/agile_alert.py
@@ -1,0 +1,185 @@
+"""Fetch tomorrow's Octopus Agile prices and alert on free-energy slots."""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+from dataclasses import dataclass
+from datetime import UTC, date, datetime, time, timedelta
+from typing import Any, Callable
+from zoneinfo import ZoneInfo
+
+API_ROOT = "https://api.octopus.energy/v1"
+
+
+@dataclass(frozen=True)
+class Config:
+    product_code: str
+    tariff_code: str
+    webhook_url: str | None = None
+    threshold: float = 0.0
+    timezone: str = "Europe/London"
+
+    @classmethod
+    def from_environment(cls) -> "Config":
+        # GitHub Actions expands unset repository variables to empty strings,
+        # so use ``or`` rather than only getenv's default argument.
+        product = os.getenv("OCTOPUS_PRODUCT_CODE") or "AGILE-24-10-01"
+        region = (os.getenv("OCTOPUS_REGION") or "C").strip().upper()
+        tariff = os.getenv("OCTOPUS_TARIFF_CODE") or f"E-1R-{product}-{region}"
+        return cls(
+            product_code=product,
+            tariff_code=tariff,
+            webhook_url=os.getenv("ALERT_WEBHOOK_URL"),
+            threshold=float(os.getenv("ALERT_THRESHOLD_PENCE") or "0"),
+            timezone=os.getenv("ALERT_TIMEZONE") or "Europe/London",
+        )
+
+
+def tomorrow_period(now: datetime, timezone: str) -> tuple[datetime, datetime, date]:
+    """Return UTC API boundaries for tomorrow in the configured local timezone."""
+    zone = ZoneInfo(timezone)
+    local_tomorrow = now.astimezone(zone).date() + timedelta(days=1)
+    start = datetime.combine(local_tomorrow, time.min, zone).astimezone(UTC)
+    end = datetime.combine(
+        local_tomorrow + timedelta(days=1), time.min, zone
+    ).astimezone(UTC)
+    return start, end, local_tomorrow
+
+
+def rates_url(config: Config, start: datetime, end: datetime) -> str:
+    product = urllib.parse.quote(config.product_code, safe="")
+    tariff = urllib.parse.quote(config.tariff_code, safe="")
+    query = urllib.parse.urlencode(
+        {
+            "period_from": start.isoformat().replace("+00:00", "Z"),
+            "period_to": end.isoformat().replace("+00:00", "Z"),
+            "page_size": 100,
+        }
+    )
+    return f"{API_ROOT}/products/{product}/electricity-tariffs/{tariff}/standard-unit-rates/?{query}"
+
+
+def fetch_rates(
+    url: str, opener: Callable[..., Any] = urllib.request.urlopen
+) -> list[dict[str, Any]]:
+    """Fetch every page from an Octopus rates response."""
+    results: list[dict[str, Any]] = []
+    while url:
+        request = urllib.request.Request(
+            url, headers={"User-Agent": "ai-systems-lab-agile-alert/1.0"}
+        )
+        with opener(request, timeout=20) as response:
+            payload = json.load(response)
+        if not isinstance(payload.get("results"), list):
+            raise ValueError("Octopus response did not contain a results list")
+        results.extend(payload["results"])
+        url = payload.get("next")
+    return results
+
+
+def cheap_slots(rates: list[dict[str, Any]], threshold: float) -> list[dict[str, Any]]:
+    return sorted(
+        (rate for rate in rates if float(rate["value_inc_vat"]) <= threshold),
+        key=lambda rate: rate["valid_from"],
+    )
+
+
+def build_message(
+    slots: list[dict[str, Any]], day: date, timezone: str, threshold: float
+) -> str:
+    zone = ZoneInfo(timezone)
+    lines = [
+        f"Octopus Agile alert for {day.isoformat()}: {len(slots)} slot(s) at or below {threshold:g}p/kWh"
+    ]
+    for slot in slots:
+        start = datetime.fromisoformat(
+            slot["valid_from"].replace("Z", "+00:00")
+        ).astimezone(zone)
+        end = datetime.fromisoformat(
+            slot["valid_to"].replace("Z", "+00:00")
+        ).astimezone(zone)
+        lines.append(
+            f"- {start:%H:%M}–{end:%H:%M}: {float(slot['value_inc_vat']):g}p/kWh"
+        )
+    return "\n".join(lines)
+
+
+def send_webhook(
+    url: str, message: str, opener: Callable[..., Any] = urllib.request.urlopen
+) -> None:
+    """POST a broadly compatible JSON message (Slack uses ``text``)."""
+    request = urllib.request.Request(
+        url,
+        data=json.dumps({"text": message}).encode(),
+        headers={
+            "Content-Type": "application/json",
+            "User-Agent": "ai-systems-lab-agile-alert/1.0",
+        },
+        method="POST",
+    )
+    with opener(request, timeout=20) as response:
+        if not 200 <= response.status < 300:
+            raise RuntimeError(f"Webhook returned HTTP {response.status}")
+
+
+def run(config: Config, now: datetime | None = None) -> int:
+    start, end, day = tomorrow_period(now or datetime.now(UTC), config.timezone)
+    slots = cheap_slots(fetch_rates(rates_url(config, start, end)), config.threshold)
+    if not slots:
+        print(f"No Octopus Agile slots at or below {config.threshold:g}p/kWh on {day}.")
+        return 0
+
+    message = build_message(slots, day, config.timezone, config.threshold)
+    print(message)
+    if not config.webhook_url:
+        print(
+            "ERROR: qualifying slots found but ALERT_WEBHOOK_URL is not configured.",
+            file=sys.stderr,
+        )
+        return 2
+    send_webhook(config.webhook_url, message)
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="print qualifying rates without sending a webhook",
+    )
+    args = parser.parse_args()
+    try:
+        config = Config.from_environment()
+        if args.dry_run:
+            # A dry run intentionally treats a missing webhook as success.
+            start, end, day = tomorrow_period(datetime.now(UTC), config.timezone)
+            slots = cheap_slots(
+                fetch_rates(rates_url(config, start, end)), config.threshold
+            )
+            print(
+                build_message(slots, day, config.timezone, config.threshold)
+                if slots
+                else f"No qualifying slots on {day}."
+            )
+            return 0
+        return run(config)
+    except (
+        urllib.error.URLError,
+        TimeoutError,
+        ValueError,
+        KeyError,
+        RuntimeError,
+    ) as exc:
+        print(f"ERROR: {exc}", file=sys.stderr)
+        return 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/projects/06-octopus-agile-alert/test_agile_alert.py
+++ b/projects/06-octopus-agile-alert/test_agile_alert.py
@@ -1,0 +1,79 @@
+import importlib.util
+import json
+import sys
+import unittest
+from datetime import UTC, datetime
+from pathlib import Path
+
+SPEC = importlib.util.spec_from_file_location(
+    "agile_alert", Path(__file__).with_name("agile_alert.py")
+)
+agile_alert = importlib.util.module_from_spec(SPEC)
+assert SPEC.loader
+sys.modules[SPEC.name] = agile_alert
+SPEC.loader.exec_module(agile_alert)
+
+
+class Response:
+    def __init__(self, payload=None, status=200):
+        self.payload = payload or {}
+        self.status = status
+
+    def read(self, *_args):
+        return json.dumps(self.payload).encode()
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, *_args):
+        return None
+
+
+class AgileAlertTests(unittest.TestCase):
+    def test_tomorrow_period_observes_british_summer_time(self):
+        start, end, day = agile_alert.tomorrow_period(
+            datetime(2026, 7, 29, 16, tzinfo=UTC), "Europe/London"
+        )
+        self.assertEqual(day.isoformat(), "2026-07-30")
+        self.assertEqual(start.isoformat(), "2026-07-29T23:00:00+00:00")
+        self.assertEqual(end.isoformat(), "2026-07-30T23:00:00+00:00")
+
+    def test_fetch_rates_follows_pagination(self):
+        responses = iter(
+            [
+                Response(
+                    {"results": [{"id": 1}], "next": "https://example.test/page-2"}
+                ),
+                Response({"results": [{"id": 2}], "next": None}),
+            ]
+        )
+        self.assertEqual(
+            agile_alert.fetch_rates(
+                "https://example.test/page-1", lambda *_args, **_kwargs: next(responses)
+            ),
+            [{"id": 1}, {"id": 2}],
+        )
+
+    def test_detects_zero_and_negative_slots(self):
+        rates = [
+            {"value_inc_vat": 2, "valid_from": "2026-07-30T00:00:00Z"},
+            {"value_inc_vat": 0, "valid_from": "2026-07-30T00:30:00Z"},
+            {"value_inc_vat": -1.2, "valid_from": "2026-07-30T01:00:00Z"},
+        ]
+        self.assertEqual(
+            [r["value_inc_vat"] for r in agile_alert.cheap_slots(rates, 0)], [0, -1.2]
+        )
+
+    def test_webhook_posts_slack_compatible_payload(self):
+        captured = {}
+
+        def open_request(request, **_kwargs):
+            captured["body"] = json.loads(request.data)
+            return Response(status=204)
+
+        agile_alert.send_webhook("https://example.test/hook", "hello", open_request)
+        self.assertEqual(captured["body"], {"text": "hello"})
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Motivation

- Provide a daily check that detects when Octopus Agile half-hour rates for a configured tariff/region are £0 or negative so users can plan around free/very-cheap slots. 
- Run the check automatically after Octopus publishes next-day rates and surface alerts via a webhook when qualifying slots are found.

### Description

- Add `projects/06-octopus-agile-alert/agile_alert.py`, a zero-dependency CLI that fetches tomorrow's half-hourly rates, follows pagination, computes local-day UTC boundaries (honouring DST), filters slots at-or-below a configurable pence threshold, and posts a Slack-compatible JSON webhook.
- Add `--dry-run` support and environment-driven configuration via `OCTOPUS_PRODUCT_CODE`, `OCTOPUS_REGION`, `OCTOPUS_TARIFF_CODE`, `ALERT_THRESHOLD_PENCE`, `ALERT_TIMEZONE`, and `ALERT_WEBHOOK_URL`.
- Add unit tests in `projects/06-octopus-agile-alert/test_agile_alert.py` covering DST-aware day boundaries, pagination, zero/negative detection, and webhook payload formatting; add documentation `projects/06-octopus-agile-alert/README.md` and a daily GitHub Actions workflow `.github/workflows/octopus-agile-alert.yml` scheduled at 16:30 UTC with manual dispatch.
- Fail explicitly when qualifying slots are found but no webhook is configured, and surface network/API/webhook errors as non-zero exit codes.

### Testing

- Ran unit tests with `python -m unittest discover -s projects/06-octopus-agile-alert -v`, all tests passed.
- Verified the module compiles with `python -m py_compile projects/06-octopus-agile-alert/agile_alert.py` and code formatting with `black` (files formatted and checked); `git diff --check` reported no issues.
- Executed a local `--dry-run` which could not reach the live Octopus API due to the environment HTTPS tunnel returning `403 Forbidden`, but mocked API and webhook behavior exercised by the unit tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a6a63f961388327945352ce05daae24)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an automated daily check for tomorrow’s Octopus Agile electricity prices.
  * Sends configurable webhook alerts when prices meet the selected threshold.
  * Supports local execution with a dry-run option and manual workflow runs.
  * Handles daylight-saving time, paginated results, and configurable tariff, region, threshold, and timezone settings.

* **Documentation**
  * Added setup instructions, configuration details, webhook payload information, and workflow guidance.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->