### PR TITLE
Adopt shared cicaid developer tools

### DIFF
--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -20,10 +20,13 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install linting tools
+    - name: Install development tools
       run: |
         python -m pip install --upgrade pip
-        pip install flake8 black
+        pip install -r requirements-dev.txt
+
+    - name: Verify shared repository automation
+      run: cicaid --help
 
     - name: Run flake8
       run: |
@@ -52,10 +55,10 @@ jobs:
       with:
         python-version: ${{ matrix.python-version }}
 
-    - name: Install shared test tooling
+    - name: Install development tools
       run: |
         python -m pip install --upgrade pip
-        pip install pytest pytest-cov pytest-asyncio
+        pip install -r requirements-dev.txt
 
     - name: Run each project's test suite in isolation
       run: |
@@ -128,10 +131,10 @@ jobs:
       with:
         python-version: '3.11'
 
-    - name: Install security tools
+    - name: Install development tools
       run: |
         python -m pip install --upgrade pip
-        pip install bandit safety
+        pip install -r requirements-dev.txt
 
     - name: Run bandit security scan
       run: |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,31 @@ Required` label to a PR to opt DeepSeek into a stronger model with a larger
 token budget. Approved PRs may get non-blocking follow-ups auto-filed as
 issues labeled `ai-suggested`.
 
+## Repository Automation
+
+This repository uses the shared
+[`cicaid-devtools`](https://github.com/leonarduk/cicaid) package for local
+issue, pull-request, and review automation. Install the development dependencies
+from the repository root:
+
+```bash
+python -m pip install -r requirements-dev.txt
+```
+
+Run `cicaid --help` to see all available commands. Common tasks include:
+
+```bash
+cicaid sync-issues
+cicaid work-on-issue 81
+cicaid local-review
+cicaid commit-and-push
+cicaid publish-pr
+```
+
+The package is pinned in `requirements-dev.txt`, and Python CI installs it and
+runs a CLI smoke check. Repository automation should be added to the shared
+package rather than copied into a local `scripts/developer_tools/` directory.
+
 ## Code of Conduct
 
 Please be respectful and constructive. This is a learning repository, not a production system. Comments like "you should just use library X" without context aren't helpful - explain the trade-offs!

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,12 @@
+# Shared repository automation. Keep this pinned to a published cicaid release so
+# local development and CI use the same issue/PR/review commands.
+cicaid-devtools @ https://github.com/leonarduk/cicaid/releases/download/v0.4.7/cicaid_devtools-0.4.7-py3-none-any.whl
+
+# Tools used by .github/workflows/python-ci.yml.
+bandit
+black
+flake8
+pytest
+pytest-asyncio
+pytest-cov
+safety


### PR DESCRIPTION
### Motivation

- Avoid maintaining a local copy of the issue/PR/review automation by adopting the shared `cicaid-devtools` package as a single source of truth.
- Ensure CI and local development use the same pinned automation tooling and smoke-test the CLI in CI.

### Description

- Add `requirements-dev.txt` with a pinned `cicaid-devtools` wheel (`v0.4.7`) and common dev tools (`bandit`, `black`, `flake8`, `pytest`, `pytest-asyncio`, `pytest-cov`, `safety`).
- Update `.github/workflows/python-ci.yml` to install `requirements-dev.txt` for lint/test/security jobs and add a CLI smoke check that runs `cicaid --help`.
- Update `CONTRIBUTING.md` with instructions to install `requirements-dev.txt` and basic `cicaid` usage examples and guidance to prefer shared automation over copying `scripts/developer_tools/` locally.

### Testing

- Ran `python -m pip install -r requirements-dev.txt` inside a clean virtualenv and the install completed successfully.
- Executed `cicaid --help` from the installed package and verified the CLI lists available commands, which succeeded.
- Parsed `.github/workflows/python-ci.yml` with `PyYAML` and asserted the presence of the `cicaid --help` smoke-check step, which succeeded.
- Ran `flake8 projects/ --count --select=E9,F63,F7,F82 --show-source --statistics` and `git diff --check` as automated checks and both completed with no blocking errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a77517e98948327b67df63023586c80)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added guidance for installing and using shared repository automation tools.
  * Documented common automation commands and contribution expectations.

* **Chores**
  * Centralized development and CI dependencies in a shared requirements file.
  * Updated continuous integration checks to use the shared dependency configuration.
  * Added a smoke check to verify repository automation is available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->