### PR TITLE
Move projects/07-multi-agent-coder to issue-worm

### DIFF
--- a/projects/07-multi-agent-coder/README.md
+++ b/projects/07-multi-agent-coder/README.md
@@ -1,0 +1,9 @@
+# Multi-Agent Coder — moved
+
+This project outgrew being one project among several and became its own
+repo: **[leonarduk/issue-worm](https://github.com/leonarduk/issue-worm)**.
+
+The design doc, milestones, and issues that were drafted here now live
+there (the design doc kept the reasoning trail, including why the
+architecture changed shape twice — see
+[issue-worm's `docs/design.md`](https://github.com/leonarduk/issue-worm/blob/main/docs/design.md)).


### PR DESCRIPTION
## Summary
- The multi-agent coder project moved to its own repo: https://github.com/leonarduk/issue-worm
- All 20 sub-issues and PR #104 in this repo are closed, each pointing to its new location
- Replaces `projects/07-multi-agent-coder`'s content with a pointer README rather than deleting the directory outright

🤖 Generated with [Claude Code](https://claude.com/claude-code)