### PR TITLE
Repin cicaid-devtools to v0.3.0 (fix CI 404)

### DIFF
--- a/.github/workflows/_ai-pr-review.yml
+++ b/.github/workflows/_ai-pr-review.yml
@@ -86,8 +86,8 @@ jobs:
 
       - name: Install cicaid-devtools
         env:
-          CICAID_WHEEL_URL: https://github.com/leonarduk/cicaid/releases/download/v0.7.8/cicaid_devtools-0.7.8-py3-none-any.whl
-          CICAID_WHEEL_SHA256: 40b407d76dd94d78f1d961bac73a3f90d57241466a6173392a0a0387ee8bdb27
+          CICAID_WHEEL_URL: https://github.com/leonarduk/cicaid/releases/download/v0.3.0/cicaid_devtools-0.3.0-py3-none-any.whl
+          CICAID_WHEEL_SHA256: 5b113d70851a58a8d6a9bbd6c1160b9569aadac486262140afedc75ecf7f179c
         run: |
           set -euo pipefail
           wheel_file="/tmp/$(basename "$CICAID_WHEEL_URL")"

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,6 +1,6 @@
 # Shared repository automation. Keep this pinned to a published cicaid release so
 # local development and CI use the same issue/PR/review commands.
-cicaid-devtools @ https://github.com/leonarduk/cicaid/releases/download/v0.4.7/cicaid_devtools-0.4.7-py3-none-any.whl
+cicaid-devtools @ https://github.com/leonarduk/cicaid/releases/download/v0.3.0/cicaid_devtools-0.3.0-py3-none-any.whl
 
 # Tools used by .github/workflows/python-ci.yml.
 bandit


### PR DESCRIPTION
## Summary
- `requirements-dev.txt` pinned `cicaid-devtools` to `v0.4.7` and `.github/workflows/_ai-pr-review.yml` pinned it to `v0.7.8`. Neither tag/release has ever existed in [leonarduk/cicaid](https://github.com/leonarduk/cicaid/releases) — the latest published release is `v0.3.0` (2026-08-26). Both pins were wrong from the moment they were introduced, not a regression from a deleted asset.
- This breaks the install step (~6s in) on every job that runs `pip install -r requirements-dev.txt`: Lint Python Code, Run Tests (3.11 & 3.12), Security Scan, and both the DeepSeek and GPT AI review jobs. Last green run on `main` was `9dfffd4`; `main`@`7fa90ee` is currently red for this reason.
- Repinned both files to `v0.3.0` (asset naming convention `cicaid_devtools-<ver>-py3-none-any.whl` is unchanged from the earlier "keep canonical wheel filename" fix in 45cd385), and recomputed/verified the wheel's SHA256 for the checksum-pinned install in `_ai-pr-review.yml`.
- Verified locally: `pip install -r requirements-dev.txt` into a clean venv succeeds and `cicaid --help` runs; `curl`+`sha256sum -c` against the new `CICAID_WHEEL_URL`/`CICAID_WHEEL_SHA256` pair passes.
- Considered adding a custom "artifact missing" error message to the install step, but pip's existing 404 error already names the exact failing URL, which is what let this be diagnosed and fixed directly — no extra tooling needed. The actual root cause was pinning to versions that were never released, not an unclear error message.

## Test plan
- [x] `pip install -r requirements-dev.txt` succeeds in a clean venv; `cicaid --help` runs
- [x] `curl` + `sha256sum -c` against the new `_ai-pr-review.yml` wheel URL/checksum passes
- [ ] CI on this PR goes green (lint, both test legs, security scan)