### PR TITLE
feat: implement the three avatar tools (#123)

### DIFF
--- a/projects/08-linkedin-avatar/avatar/tools.py
+++ b/projects/08-linkedin-avatar/avatar/tools.py
@@ -1,1 +1,192 @@
-"""record_contact, record_unknown_question, lookup_project. Implemented in issue #123."""
+"""record_contact, record_unknown_question, lookup_project.
+
+Three tools for the DeepSeek tool-use loop (avatar/llm.py). Two send a Pushover
+notification, one reads github.json locally. None of them may raise — a failed
+notification or an unknown project name must degrade to an error result, never
+take down the chat turn. See docs/design.md §5.
+"""
+
+import difflib
+import json
+import logging
+import os
+from pathlib import Path
+
+import requests
+
+logger = logging.getLogger(__name__)
+
+PUSHOVER_URL = "https://api.pushover.net/1/messages.json"
+GITHUB_SNAPSHOT_PATH = (
+    Path(__file__).resolve().parent.parent / "knowledge" / "github.json"
+)
+
+RECORD_CONTACT = "record_contact"
+RECORD_UNKNOWN_QUESTION = "record_unknown_question"
+LOOKUP_PROJECT = "lookup_project"
+
+TOOL_DEFINITIONS = [
+    {
+        "type": "function",
+        "function": {
+            "name": RECORD_CONTACT,
+            "description": (
+                "Record that a visitor wants to be contacted. Sends a push "
+                "notification with their details; call this whenever a visitor "
+                "gives an email address or asks to be put in touch."
+            ),
+            "strict": True,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "email": {
+                        "type": "string",
+                        "description": "The visitor's email address.",
+                    },
+                    "name": {
+                        "type": ["string", "null"],
+                        "description": "The visitor's name, if given.",
+                    },
+                    "notes": {
+                        "type": ["string", "null"],
+                        "description": "Anything relevant about why they want to talk.",
+                    },
+                },
+                "required": ["email", "name", "notes"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": RECORD_UNKNOWN_QUESTION,
+            "description": (
+                "Record a question that could not be answered from the available "
+                "knowledge. Call this instead of guessing whenever you don't know "
+                "the answer — never invent an answer about Steve's experience."
+            ),
+            "strict": True,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "question": {
+                        "type": "string",
+                        "description": "The visitor's question, verbatim.",
+                    },
+                },
+                "required": ["question"],
+                "additionalProperties": False,
+            },
+        },
+    },
+    {
+        "type": "function",
+        "function": {
+            "name": LOOKUP_PROJECT,
+            "description": (
+                "Fetch the full record for one GitHub repo — description, "
+                "languages, README excerpt and any curated note. Use this when "
+                "the conversation goes into detail on a specific project named "
+                "in the GitHub index."
+            ),
+            "strict": True,
+            "parameters": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The repo name, as it appears in the GitHub index.",
+                    },
+                },
+                "required": ["name"],
+                "additionalProperties": False,
+            },
+        },
+    },
+]
+
+
+def _pushover_notify(title, message):
+    """POST a Pushover notification. Never raises — logs and returns a status dict."""
+    user = os.environ.get("PUSHOVER_USER")
+    token = os.environ.get("PUSHOVER_TOKEN")
+
+    if not user or not token:
+        logger.info("Pushover not configured; logging instead. %s: %s", title, message)
+        return {"status": "logged", "detail": "PUSHOVER_USER/PUSHOVER_TOKEN not set"}
+
+    try:
+        response = requests.post(
+            PUSHOVER_URL,
+            data={"token": token, "user": user, "title": title, "message": message},
+            timeout=10,
+        )
+        response.raise_for_status()
+    except requests.RequestException:
+        logger.exception("Pushover notification failed: %s", title)
+        return {"status": "failed", "detail": "notification could not be sent"}
+
+    return {"status": "sent"}
+
+
+def record_contact(email, name=None, notes=None):
+    """Notify me that a visitor wants to be contacted."""
+    lines = [f"Email: {email}"]
+    if name:
+        lines.append(f"Name: {name}")
+    if notes:
+        lines.append(f"Notes: {notes}")
+    result = _pushover_notify("LinkedIn Avatar: contact request", "\n".join(lines))
+    return {"recorded": result["status"] in ("sent", "logged"), **result}
+
+
+def record_unknown_question(question):
+    """Notify me that the avatar didn't know the answer to something."""
+    result = _pushover_notify("LinkedIn Avatar: unknown question", question)
+    return {"recorded": result["status"] in ("sent", "logged"), **result}
+
+
+def lookup_project(name):
+    """Fetch the full github.json record for one repo, fuzzy-matching the name."""
+    try:
+        raw = GITHUB_SNAPSHOT_PATH.read_text(encoding="utf-8")
+        records = json.loads(raw)
+    except (OSError, json.JSONDecodeError):
+        logger.exception("Could not read GitHub snapshot at %s", GITHUB_SNAPSHOT_PATH)
+        return {
+            "found": False,
+            "message": "the GitHub project index is unavailable right now",
+        }
+
+    by_name = {record["name"].lower(): record for record in records}
+    query = name.strip().lower()
+
+    if query in by_name:
+        return {"found": True, "project": by_name[query]}
+
+    matches = difflib.get_close_matches(query, by_name.keys(), n=1, cutoff=0.6)
+    if matches:
+        return {"found": True, "project": by_name[matches[0]]}
+
+    return {"found": False, "message": f"no project matching '{name}' was found"}
+
+
+_DISPATCH_TABLE = {
+    RECORD_CONTACT: record_contact,
+    RECORD_UNKNOWN_QUESTION: record_unknown_question,
+    LOOKUP_PROJECT: lookup_project,
+}
+
+
+def dispatch(name, arguments):
+    """Call a tool by name with keyword arguments. Never raises."""
+    handler = _DISPATCH_TABLE.get(name)
+    if handler is None:
+        return {"error": f"unknown tool: {name}"}
+
+    try:
+        return handler(**arguments)
+    except TypeError:
+        logger.exception("Bad arguments for tool %s: %r", name, arguments)
+        return {"error": f"invalid arguments for tool: {name}"}

--- a/projects/08-linkedin-avatar/tests/test_tools.py
+++ b/projects/08-linkedin-avatar/tests/test_tools.py
@@ -1,0 +1,203 @@
+"""Tests for avatar/tools.py. No test performs a real network call."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import avatar.tools as tools  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, status_code=200):
+        self.status_code = status_code
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise tools.requests.HTTPError(f"status {self.status_code}")
+
+
+@pytest.fixture(autouse=True)
+def _clear_pushover_env(monkeypatch):
+    monkeypatch.delenv("PUSHOVER_USER", raising=False)
+    monkeypatch.delenv("PUSHOVER_TOKEN", raising=False)
+
+
+class TestPushoverNotify:
+    def test_logs_when_credentials_missing(self):
+        result = tools._pushover_notify("title", "message")
+        assert result["status"] == "logged"
+
+    def test_posts_when_credentials_present(self, monkeypatch):
+        monkeypatch.setenv("PUSHOVER_USER", "u")
+        monkeypatch.setenv("PUSHOVER_TOKEN", "t")
+
+        captured = {}
+
+        def fake_post(url, data, timeout):
+            captured["url"] = url
+            captured["data"] = data
+            return FakeResponse(200)
+
+        monkeypatch.setattr(tools.requests, "post", fake_post)
+
+        result = tools._pushover_notify("title", "message")
+
+        assert result["status"] == "sent"
+        assert captured["url"] == tools.PUSHOVER_URL
+        assert captured["data"]["title"] == "title"
+        assert captured["data"]["message"] == "message"
+        assert captured["data"]["token"] == "t"
+        assert captured["data"]["user"] == "u"
+
+    def test_http_failure_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv("PUSHOVER_USER", "u")
+        monkeypatch.setenv("PUSHOVER_TOKEN", "t")
+
+        def fake_post(url, data, timeout):
+            return FakeResponse(500)
+
+        monkeypatch.setattr(tools.requests, "post", fake_post)
+
+        result = tools._pushover_notify("title", "message")
+
+        assert result["status"] == "failed"
+
+    def test_connection_error_does_not_raise(self, monkeypatch):
+        monkeypatch.setenv("PUSHOVER_USER", "u")
+        monkeypatch.setenv("PUSHOVER_TOKEN", "t")
+
+        def fake_post(url, data, timeout):
+            raise tools.requests.ConnectionError("no network")
+
+        monkeypatch.setattr(tools.requests, "post", fake_post)
+
+        result = tools._pushover_notify("title", "message")
+
+        assert result["status"] == "failed"
+
+
+class TestRecordContact:
+    def test_happy_path_logs_without_credentials(self):
+        result = tools.record_contact(
+            email="a@example.com", name="Alice", notes="wants a chat"
+        )
+        assert result["recorded"] is True
+        assert result["status"] == "logged"
+
+    def test_optional_fields_default_to_none(self):
+        result = tools.record_contact(email="a@example.com")
+        assert result["recorded"] is True
+
+    def test_no_api_key_or_env_var_in_notification(self, monkeypatch):
+        monkeypatch.setenv("PUSHOVER_USER", "u")
+        monkeypatch.setenv("PUSHOVER_TOKEN", "super-secret-token")
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "sk-should-never-appear")
+
+        captured = {}
+
+        def fake_post(url, data, timeout):
+            captured["message"] = data["message"]
+            return FakeResponse(200)
+
+        monkeypatch.setattr(tools.requests, "post", fake_post)
+
+        tools.record_contact(email="a@example.com", name="Alice", notes="hello")
+
+        assert "super-secret-token" not in captured["message"]
+        assert "sk-should-never-appear" not in captured["message"]
+
+
+class TestRecordUnknownQuestion:
+    def test_happy_path(self):
+        result = tools.record_unknown_question(question="What did he do at Acme?")
+        assert result["recorded"] is True
+
+    def test_pushover_failure_is_non_fatal(self, monkeypatch):
+        monkeypatch.setenv("PUSHOVER_USER", "u")
+        monkeypatch.setenv("PUSHOVER_TOKEN", "t")
+        monkeypatch.setattr(
+            tools.requests,
+            "post",
+            lambda *a, **k: (_ for _ in ()).throw(tools.requests.ConnectionError()),
+        )
+
+        result = tools.record_unknown_question(question="What did he do at Acme?")
+
+        assert result["recorded"] is False
+        assert result["status"] == "failed"
+
+
+class TestLookupProject:
+    @pytest.fixture
+    def snapshot(self, tmp_path, monkeypatch):
+        records = [
+            {
+                "name": "issue-worm",
+                "description": "Multi-agent coder",
+                "url": "https://github.com/leonarduk/issue-worm",
+                "topics": ["agents"],
+                "languages": ["Python"],
+                "stars": 3,
+                "pushed_at": "2026-08-20",
+                "readme_excerpt": "...",
+                "curated_note": None,
+            },
+        ]
+        path = tmp_path / "github.json"
+        path.write_text(json.dumps(records), encoding="utf-8")
+        monkeypatch.setattr(tools, "GITHUB_SNAPSHOT_PATH", path)
+        return path
+
+    def test_exact_match(self, snapshot):
+        result = tools.lookup_project(name="issue-worm")
+        assert result["found"] is True
+        assert result["project"]["name"] == "issue-worm"
+
+    def test_case_insensitive_match(self, snapshot):
+        result = tools.lookup_project(name="Issue-Worm")
+        assert result["found"] is True
+
+    def test_fuzzy_match(self, snapshot):
+        result = tools.lookup_project(name="issueworm")
+        assert result["found"] is True
+        assert result["project"]["name"] == "issue-worm"
+
+    def test_no_match_does_not_raise(self, snapshot):
+        result = tools.lookup_project(name="totally-unrelated-repo-xyz")
+        assert result["found"] is False
+        assert "message" in result
+
+    def test_missing_snapshot_file_does_not_raise(self, tmp_path, monkeypatch):
+        monkeypatch.setattr(
+            tools, "GITHUB_SNAPSHOT_PATH", tmp_path / "does-not-exist.json"
+        )
+        result = tools.lookup_project(name="issue-worm")
+        assert result["found"] is False
+
+
+class TestDispatch:
+    def test_dispatches_known_tool(self):
+        result = tools.dispatch(tools.RECORD_UNKNOWN_QUESTION, {"question": "hi"})
+        assert result["recorded"] is True
+
+    def test_unknown_tool_name_returns_error_without_raising(self):
+        result = tools.dispatch("delete_everything", {})
+        assert "error" in result
+
+    def test_bad_arguments_return_error_without_raising(self):
+        result = tools.dispatch(tools.RECORD_CONTACT, {"unexpected_field": "x"})
+        assert "error" in result
+
+
+class TestToolDefinitions:
+    def test_every_definition_is_strict_and_closed(self):
+        for tool in tools.TOOL_DEFINITIONS:
+            function = tool["function"]
+            assert function["strict"] is True
+            params = function["parameters"]
+            assert params["additionalProperties"] is False
+            assert set(params["required"]) == set(params["properties"].keys())


### PR DESCRIPTION
## Summary
- Implements `record_contact`, `record_unknown_question`, `lookup_project` in `avatar/tools.py` with DeepSeek/OpenAI strict-mode tool schemas (`additionalProperties: false`, every property listed in `required`, per design §5).
- `dispatch(name, arguments)` never raises: unknown tool name and bad arguments both degrade to an `{"error": ...}` result.
- Pushover notifications log instead of posting when `PUSHOVER_USER`/`PUSHOVER_TOKEN` are unset, and a Pushover HTTP failure or connection error is caught and returned as a non-fatal `{"status": "failed"}` rather than raising.
- `lookup_project` fuzzy-matches the repo name (exact, then case-insensitive, then `difflib.get_close_matches`) against `knowledge/github.json`, and returns a clean "not found" result rather than raising — including when the snapshot file itself is missing.

Fixes #123

## Test plan
- [x] `pytest projects/08-linkedin-avatar` — 20 passed, including happy path, missing credentials, Pushover HTTP failure, unknown tool name, and `lookup_project` miss, per the issue's success criteria
- [x] No test performs a real network call — `requests.post` is monkeypatched throughout
- [x] A dedicated test asserts no API key or Pushover token ever ends up in a notification body
- [x] `black --check` and `flake8 --max-line-length=127` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)