### PR TITLE
feat: build the GitHub portfolio snapshot builder (#120)

### DIFF
--- a/projects/08-linkedin-avatar/build/build_github_snapshot.py
+++ b/projects/08-linkedin-avatar/build/build_github_snapshot.py
@@ -1,0 +1,213 @@
+"""Snapshot leonarduk's public GitHub repos into knowledge/github.json.
+
+Usage:
+    python build/build_github_snapshot.py --user leonarduk --out knowledge/github.json
+
+Baking the snapshot at build time (rather than calling the API mid-conversation)
+keeps chat replies fast, avoids rate limits, and means no GitHub token is present
+at chat time. See docs/design.md §3.3.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+from pathlib import Path
+
+import requests
+
+GITHUB_API = "https://api.github.com"
+KNOWLEDGE_DIR = Path(__file__).resolve().parent.parent / "knowledge"
+README_EXCERPT_LIMIT = 1200
+
+HEADING_LINE_RE = re.compile(r"^##\s+(\S+)\s*$")
+
+IMAGE_OR_BADGE_RE = re.compile(r"!\[[^\]]*\]\([^)]*\)")
+LINK_RE = re.compile(r"\[([^\]]*)\]\([^)]*\)")
+HTML_TAG_RE = re.compile(r"<[^>]+>")
+HEADING_MARKER_RE = re.compile(r"^#{1,6}\s*", re.MULTILINE)
+
+# Paired emphasis/code delimiters only — a bare "_" or "*" inside an
+# identifier (GITHUB_TOKEN, multi_agent_coder) must survive untouched.
+BOLD_STAR_RE = re.compile(r"\*\*([^*\n]+)\*\*")
+BOLD_UNDERSCORE_RE = re.compile(r"__([^_\n]+)__")
+ITALIC_STAR_RE = re.compile(r"\*([^*\n]+)\*")
+CODE_SPAN_RE = re.compile(r"`([^`\n]+)`")
+
+BLANK_RUN_RE = re.compile(r"\n{3,}")
+
+
+class GitHubAPIError(Exception):
+    """A GitHub API call failed with a non-recoverable error."""
+
+
+class GitHubRateLimitError(GitHubAPIError):
+    """The GitHub API rate limit was exhausted."""
+
+
+def _get(url, token, params=None, accept="application/vnd.github+json"):
+    headers = {"Accept": accept}
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
+    response = requests.get(url, headers=headers, params=params, timeout=15)
+
+    if response.status_code == 403 and response.headers.get("X-RateLimit-Remaining") == "0":
+        raise GitHubRateLimitError(f"GitHub API rate limit exceeded fetching {url}")
+    if response.status_code >= 400 and response.status_code != 404:
+        raise GitHubAPIError(f"GitHub API error {response.status_code} fetching {url}")
+
+    return response
+
+
+def fetch_repos(user, token=None):
+    """Return public, non-fork, non-archived repos owned by `user`."""
+    repos = []
+    page = 1
+    while True:
+        response = _get(
+            f"{GITHUB_API}/users/{user}/repos",
+            token,
+            params={"type": "owner", "per_page": 100, "page": page},
+        )
+        batch = response.json()
+        if not batch:
+            break
+        repos.extend(batch)
+        if len(batch) < 100:
+            break
+        page += 1
+
+    return [
+        repo
+        for repo in repos
+        if not repo.get("fork") and not repo.get("archived") and not repo.get("private")
+    ]
+
+
+def fetch_languages(owner, name, token=None):
+    """Return the repo's languages, most-used first, ties broken alphabetically."""
+    response = _get(f"{GITHUB_API}/repos/{owner}/{name}/languages", token)
+    if response.status_code != 200:
+        return []
+    data = response.json()
+    return sorted(data.keys(), key=lambda lang: (-data[lang], lang))
+
+
+def fetch_readme(owner, name, token=None):
+    """Return the repo's README as raw text, or "" if it has none."""
+    response = _get(
+        f"{GITHUB_API}/repos/{owner}/{name}/readme",
+        token,
+        accept="application/vnd.github.raw",
+    )
+    if response.status_code == 404:
+        return ""
+    return response.text
+
+
+def strip_markdown(text):
+    """Remove badges, images, links, headings and emphasis markup from README text.
+
+    Only paired emphasis/code delimiters are stripped — a bare "_" or "*"
+    inside an identifier (GITHUB_TOKEN, multi_agent_coder) is left alone,
+    since there's no reliable way to tell it apart from real emphasis syntax.
+    """
+    text = IMAGE_OR_BADGE_RE.sub("", text)
+    text = LINK_RE.sub(r"\1", text)
+    text = HTML_TAG_RE.sub("", text)
+    text = HEADING_MARKER_RE.sub("", text)
+    text = BOLD_STAR_RE.sub(r"\1", text)
+    text = BOLD_UNDERSCORE_RE.sub(r"\1", text)
+    text = ITALIC_STAR_RE.sub(r"\1", text)
+    text = CODE_SPAN_RE.sub(r"\1", text)
+    text = BLANK_RUN_RE.sub("\n\n", text)
+    return text.strip()
+
+
+def readme_excerpt(readme_text, limit=README_EXCERPT_LIMIT):
+    return strip_markdown(readme_text)[:limit]
+
+
+def parse_projects_md(path):
+    """Parse `## repo-name` sections into {repo_name: note_text}."""
+    if not path.exists():
+        return {}
+
+    notes = {}
+    current_name = None
+    buffer = []
+
+    def flush():
+        if current_name is not None:
+            notes[current_name] = "\n".join(buffer).strip()
+
+    for line in path.read_text(encoding="utf-8").splitlines():
+        match = HEADING_LINE_RE.match(line)
+        if match:
+            flush()
+            current_name = match.group(1)
+            buffer = []
+        else:
+            buffer.append(line)
+    flush()
+
+    return notes
+
+
+def build_snapshot(user, token=None, projects_md_path=None):
+    """Fetch and assemble one record per repo, sorted deterministically by name."""
+    if projects_md_path is None:
+        projects_md_path = KNOWLEDGE_DIR / "projects.md"
+    curated_notes = parse_projects_md(projects_md_path)
+
+    records = []
+    for repo in fetch_repos(user, token):
+        owner = repo["owner"]["login"]
+        name = repo["name"]
+        readme_text = fetch_readme(owner, name, token)
+
+        records.append(
+            {
+                "name": name,
+                "description": repo.get("description") or "",
+                "url": repo["html_url"],
+                "topics": sorted(repo.get("topics") or []),
+                "languages": fetch_languages(owner, name, token),
+                "stars": repo.get("stargazers_count", 0),
+                "pushed_at": (repo.get("pushed_at") or "")[:10],
+                "readme_excerpt": readme_excerpt(readme_text),
+                "curated_note": curated_notes.get(name),
+            }
+        )
+
+    records.sort(key=lambda record: record["name"])
+    return records
+
+
+def write_snapshot(records, out_path):
+    out_path.write_text(json.dumps(records, indent=2, sort_keys=True) + "\n", encoding="utf-8")
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--user", default="leonarduk")
+    parser.add_argument("--out", default=str(KNOWLEDGE_DIR / "github.json"))
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GITHUB_TOKEN")
+
+    try:
+        records = build_snapshot(args.user, token)
+    except GitHubAPIError as exc:
+        print(f"Error: {exc}", file=sys.stderr)
+        return 1
+
+    write_snapshot(records, Path(args.out))
+    print(f"Wrote {len(records)} repos to {args.out}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/projects/08-linkedin-avatar/knowledge/github.json
+++ b/projects/08-linkedin-avatar/knowledge/github.json
@@ -1,0 +1,244 @@
+[
+  {
+    "curated_note": null,
+    "description": "Self-directed learning project building AI systems tools. Created 7 MCP servers that enable LLMs to interact with GitHub, filesystems, and web APIs. Learning to apply backend engineering patterns (rate limiting, security, error handling) to AI systems.",
+    "languages": [
+      "Python",
+      "Dockerfile"
+    ],
+    "name": "ai-systems-lab",
+    "pushed_at": "2026-08-30",
+    "readme_excerpt": "AI Systems Lab\n\nPersonal portfolio demonstrating AI systems engineering capabilities.\n\nThis repository documents my transition into AI systems engineering. Rather than just theory, I'm building production-quality tools and learning by doing. Some projects outgrow this lab and become their own repos \u2014 those are listed separately below.\n\n---\n\n\ud83c\udfaf What I'm Building (in this repo)\n\nMCP Server Suite\nA collection of production-ready Model Context Protocol servers that enable LLMs to interact with external systems \u2014 GitHub, filesystems, git operations, email, web search, and more.\n\nStatus: Production-ready, actively maintained\nTech stack: Python, AsyncIO, MCP Protocol, REST APIs, GitHub API, SMTP\n\nGitHub SDK App\nA GitHub App built on the GitHub SDK for automating repo/issue/PR workflows.\n\nGmail Inbox Labeler\nMoves messages out of a Gmail inbox into existing labels using a local Ollama model to classify them \u2014 no email content ever leaves the machine to a hosted LLM.\n\nTech stack: Python, Gmail API (OAuth2), Ollama\n\nLLM Cost Comparison\nInteractive tool that estimates and compares the real cost of running an LLM locally (owned hardware or rented cloud GPU) against hosted APIs, based on your ow",
+    "stars": 1,
+    "topics": [],
+    "url": "https://github.com/leonarduk/ai-systems-lab"
+  },
+  {
+    "curated_note": "My biggest and most active personal project by a distance: a Python/FastAPI investment and portfolio\ntracking platform on AWS CDK/Lambda, with thousands of commits and an AI-powered PR review pipeline\n(Claude, GPT, DeepSeek) running on every pull request. It's the clearest evidence of what an\nAI-directed workflow looks like in practice \u2014 I'm mostly directing and reviewing rather than typing,\nand the commit history shows it. `allotmint-pro` and `allotmint-mcp` (a standalone MCP server exposing\nthe platform, including an agentic research tool, to AI clients) sit alongside it.",
+    "description": "Serverless investment tracking and portfolio analytics system with React frontend, FastAPI backend, and AWS deployment",
+    "languages": [
+      "Python",
+      "TypeScript",
+      "Shell",
+      "PowerShell",
+      "CSS",
+      "JavaScript",
+      "HTML",
+      "Makefile",
+      "Dockerfile"
+    ],
+    "name": "allotmint",
+    "pushed_at": "2026-08-30",
+    "readme_excerpt": "AllotMint \ud83c\udf31\ud83d\udcb7\n\nAllotMint is a family investing platform with a FastAPI backend, React/TypeScript frontend, and AWS deployment support.\n\nOpen-core editions\n\nThis repository is the public AllotMint application shell. It boots and serves\nthe free portfolio-management routes without any private dependency. The paid\nengine is distributed separately as the private\nallotmint-pro package.\n\n| Public application | Optional allotmint-pro engine |\n| --- | --- |\n| FastAPI and React application, portfolio data and reports, authentication, and local/demo workflows | Fundamental screener, VaR and Sharpe calculations, compliance rules, tax allowances, and anomaly repair |\n\nPremium endpoints remain present in the public API contract. When\nallotmint-pro is not installed, they return HTTP 402 Payment Required with\nan upgrade pointer instead of preventing the application from starting. Users\nwith access to the private package can install the integration extra with\npython -m pip install '.[pro]'.\n\nScreenshots\n\n| Portfolio view | Screener |\n| --- | --- |\n|  |  |\n\n| Reports | Mobile |\n| --- | --- |\n|  |  |\n\nLanguage guidelines\n\nAll code, comments, commit messages, documentation, and PR/issue text in this\nr",
+    "stars": 1,
+    "topics": [
+      "aws",
+      "aws-cdk",
+      "aws-lambda",
+      "fastapi",
+      "investing",
+      "portfolio",
+      "python",
+      "react",
+      "typescript"
+    ],
+    "url": "https://github.com/leonarduk/allotmint"
+  },
+  {
+    "curated_note": null,
+    "description": "Standalone MCP server for AllotMint (Spring Boot 4.1.0 + Java 25, MCP Java SDK) \u2014 Spring Boot MCP server for AllotMint API + local file access",
+    "languages": [
+      "Python",
+      "Java",
+      "PowerShell",
+      "Dockerfile"
+    ],
+    "name": "allotmint-mcp",
+    "pushed_at": "2026-08-30",
+    "readme_excerpt": "allotmint-mcp\n\nStandalone MCP server for AllotMint, built with Spring Boot 4.1.0, Java 25, and the MCP Java SDK. It exposes the same tools over stdio (for Claude Desktop and MCP Inspector) and HTTP streamable transport (/mcp).\n\nFor the intended users, product boundaries, build-versus-buy decisions, and rough running-cost\nprofile, see Product framing.\n\nArchitecture\n\n```mermaid\nflowchart LR\n    subgraph clients[\"MCP clients\"]\n        CD[\"Claude Desktop /\\nother MCP clients\"]\n        CLI[\"mcp-client CLI\\n(client.py)\"]\n        WEBUI[\"webui.py /\\ngradio_ui.py\"]\n    end\n\n    subgraph server[\"allotmint-mcp server (Java, Spring Boot, MCP Java SDK)\"]\n        MCP[\"MCP tools\\nallotmint_health / instrument / market /\\nportfolio / reconcile / data_quality\"]\n        RESEARCH[\"allotmint_research (opt-in)\"]\n    end\n\n    BACKEND[(\"AllotMint backend\\n(REST API)\")]\n\n    subgraph sidecar[\"research-agent sidecar (Python, FastAPI, Pydantic AI)\"]\n        AGENT[\"/research/ask\"]\n        RETRIEVAL[\"retrieval.py\"]\n    end\n\n    PGVECTOR[(\"pgvector\\n(Postgres)\")]\n    LLM[\"LLM\\n(Ollama local, or DeepSeek/OpenAI-compatible)\"]\n\n    CD -- \"stdio or HTTP /mcp\" --> MCP\n    CLI -- \"streamable HTTP /mcp\" --> MCP\n    W",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/allotmint-mcp"
+  },
+  {
+    "curated_note": "CLI and automation tooling for AI-assisted GitHub issue and PR workflows \u2014 setup, review, and triage.\nBuilt to support the same kind of AI-directed development I use on `allotmint` and this lab, rather\nthan as a one-off experiment.",
+    "description": "GitHub issue/PR plumbing CLI (free shell) - the LLM review/triage engine is cicaid-pro",
+    "languages": [
+      "Python",
+      "Shell"
+    ],
+    "name": "cicaid",
+    "pushed_at": "2026-08-28",
+    "readme_excerpt": "cicaid\n\nOne CLI for the GitHub-plumbing every repo ends up needing: sync issues,\nbranch onto one, check out a PR, run the repo's local CI checks, link a PR\nback to its issue, auto-merge green Dependabot PRs. Install once \u2014 every\ncommand auto-detects the repo from your origin remote.\n\nThis is the free shell. The LLM-backed commands (triage-issues,\nreview-issue, create-issue, local-review, pr-review,\ncommit-and-push, implement-issue-with-aider, clear-ai-slop-issues) are\npart of cicaid-pro, a private\npackage \u2014 cicaid  reports itself unavailable with a pointer there\nuntil it's installed.\n\nInstall\n\n```bash\npip install \"cicaid-devtools @ https://github.com/leonarduk/cicaid/releases/download/v0.3.0/cicaid_devtools-0.3.0-py3-none-any.whl\"\n```\n\nThis always points at the latest release \u2014 the install command above is updated\nautomatically as part of every release, so it never goes stale. Want an older\nversion instead? See Releases for\nevery version's exact install command.\n\nThe standard installation loads GITHUB_TOKEN and similar from a repo-root\n.env file for local runs (CI should set real env vars instead). The historical\n[dotenv] extra remains available as a backwards-compatible alias:\n\n``",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/cicaid"
+  },
+  {
+    "curated_note": null,
+    "description": "For CozyCatsLondon site",
+    "languages": [
+      "CSS",
+      "HTML"
+    ],
+    "name": "cozycatslondon",
+    "pushed_at": "2024-11-05",
+    "readme_excerpt": "cozycatslondon\n\nThis publishes to \nhttp://cozycatslondon.co.uk",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/cozycatslondon"
+  },
+  {
+    "curated_note": "A multi-agent coder that works GitHub issues end-to-end, using local LLMs via Ollama. It started as\n`07-multi-agent-coder` inside this lab and outgrew it enough to become its own repo. It's deliberately\nscoped as a fallback for when cloud LLM tokens (Claude, DeepSeek) run out, not a competitor to a\nfully-tokened cloud coding session \u2014 judge it against \"one local model, no scaffolding\" as the\nbaseline, and it earns its complexity by beating that.",
+    "description": "Local LLM issue-to-PR pipeline: GitHub issues as the queue (free shell)",
+    "languages": [
+      "Python"
+    ],
+    "name": "issue-worm",
+    "pushed_at": "2026-08-26",
+    "readme_excerpt": "issue-worm\n\nGive it an issue. It sorts it out.\n\nissue-worm turns GitHub issues into pull requests using LLMs. This repo is\nthe free shell: issue filing, a standalone single-pass build, and run\nhistory. The full automated review \u2192 implement \u2192 verify pipeline with a\nverifier/retry loop and a scheduler (triage, poll) is\nissue-worm-pro, a private\npackage \u2014 see Access below.\n\nInstalling issue-worm-pro upgrades this shell in place rather than\nreplacing it: the issue-worm command stays the same, and build starts\nrunning pro's full pipeline instead of the single pass described here.\n\nWhat this package does today\n\n- issue-worm create \u2014 file a new issue, guided interactively (via\n  cicaid).\n- issue-worm build  --repo owner/name \u2014 a deterministic\n  (non-LLM) check that the issue is scoped enough to dispatch (an\n  ## Implementation notes section with FILES:/DONE:), then a single\n  pass through a local Ollama coder that writes the proposed changes to\n  the working tree. No verifier/retry loop, no scheduler. **With\n  issue-worm-pro installed this command runs pro's pipeline instead**, so\n  the behaviour described here is what you get on the free tier alone.\n- issue-worm history \u2014 list or inspect",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/issue-worm"
+  },
+  {
+    "curated_note": null,
+    "description": "",
+    "languages": [],
+    "name": "leonarduk",
+    "pushed_at": "2026-08-26",
+    "readme_excerpt": "Steve Leonard\nSenior software engineer with 20+ years in financial services, \ncurrently expanding into AI and LLM-powered systems.\n\nWhat I build\n- \ud83e\udd16 LLM-powered systems and MCP tool servers\n- \u2601\ufe0f Serverless AWS architectures  \n- \ud83d\udcca Financial data platforms and risk systems\n- \ud83c\udfb5 Real-time audio/DSP systems with CUDA-accelerated ML inference\n\nCurrently working on\n\nCiCAID, IssueWorm, and Doodlebug - tools to automate and simplify code development from issue to release\n- cicaid (public) \u2014 GitHub plumbing CLI: sync issues, work-on-issue/PR, dependabot auto-merge, local CI checks, PR linking\n- cicaid-pro (private) \u2014 adds the AI engine on top: LLM code review for local diffs and PRs (Claude/DeepSeek/GPT/Ollama), issue triage and AI-slop cleanup, AI-drafted commit/PR messages, aider integration\n- issue-worm (public) \u2014 CLI shell: config, workspace management, run history, version checks\n- issue-worm-pro (private) \u2014 the multi-agent engine: Coder\u2192Verifier\u2192Analyser orchestration loop, scheduler (poll/dispatch/label lifecycle), the coder/analyser/triage agents, and the cicaid-pro bridge\n- doodlebug (private) \u2014 CLI tool that audits a website against a QA plan specified in YAML \u2014 it will be split in",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/leonarduk"
+  },
+  {
+    "curated_note": null,
+    "description": "Python CLI that converts OpenAPI/Swagger specifications into production-ready MCP server templates in TypeScript",
+    "languages": [
+      "Python",
+      "TypeScript",
+      "Jinja"
+    ],
+    "name": "mcp-toolsmith",
+    "pushed_at": "2026-03-24",
+    "readme_excerpt": "mcp-toolsmith\n\nGenerate production-ready TypeScript MCP server templates directly from OpenAPI 3.x specs.\n\nInstall\n\n```bash\npip install mcp-toolsmith\n```\n\nQuick usage\n\n```bash\nmcp-toolsmith generate https://petstore3.swagger.io/api/v3/openapi.json --out generated-petstore\n```\n\nThen run the generated server:\n\n```bash\ncd generated-petstore\nnpm install\nnpm run build\nnpm start\n```\n\nFor a complete walkthrough (including Claude Desktop setup), see Quickstart.\n\nPython CLI that converts OpenAPI/Swagger specifications into production-ready MCP server templates in TypeScript.\n\nQuick install\n\n```bash\npip install mcp-toolsmith\n```\n\nFeatures\n\n| Capability | Status | Notes |\n| --- | --- | --- |\n| OpenAPI 3.x ingestion | \u2705 | Validates and extracts operations from OpenAPI 3.x documents. |\n| TypeScript ESM output | \u2705 | Generates a Node 20+ ESM MCP server scaffold. |\n| Quality score report | \u2705 | Emits scoring dimensions and findings in CLI output/report.json. |\n| Agent integration snippets | \u2705 | Generates Claude Desktop, VS Code, and LangChain snippets. |\n\nDocumentation\n\n- Quickstart\n- Troubleshooting FAQ\n- Architecture ADRs\n- Petstore golden example output",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/mcp-toolsmith"
+  },
+  {
+    "curated_note": null,
+    "description": "Serverless pipeline tracking UK house price statistics using AWS Lambda, DynamoDB, API Gateway and Terraform \u2014 built to support a published Medium article",
+    "languages": [
+      "HTML",
+      "HCL",
+      "Python",
+      "Jupyter Notebook",
+      "Batchfile"
+    ],
+    "name": "medium-lambda-web-scraper-demo",
+    "pushed_at": "2024-07-06",
+    "readme_excerpt": "medium-lambda-web-scraper-demo\nProject code to support an article written on Medium.com\n\nPart One\n\nhttps://medium.com/@steveleonard11/how-i-track-house-price-stats-using-aws-lambda-dynamodb-api-gateway-and-terraform-part-one-d04e4b416b6a\n\nCode is in the part_one folder and contains all the code needed to implement the code mentioned in the first article.\n\nPart Two\n\nhttps://medium.com/@steveleonard11/how-i-track-house-price-stats-using-aws-lambda-dynamodb-api-gateway-and-terraform-part-two-9f087b924c19\n\nCode is in the part_two folder and contains all the code in part_one.\nThis is so that you can create fewer Terraform workspaces if you are using\nthis as a template for your own work.",
+    "stars": 1,
+    "topics": [],
+    "url": "https://github.com/leonarduk/medium-lambda-web-scraper-demo"
+  },
+  {
+    "curated_note": null,
+    "description": "A tool that reads timeseries from Yahoo and Alphavantage and does analysis.  ",
+    "languages": [
+      "Java",
+      "Python",
+      "JavaScript",
+      "Kotlin",
+      "HTML",
+      "Batchfile",
+      "Dockerfile"
+    ],
+    "name": "pension-risk-management-system",
+    "pushed_at": "2026-08-22",
+    "readme_excerpt": "pension-risk-management-system\n\n \n\nA tool that reads timeseries from Yahoo and Alphavantage and does analysis.\n\nDevelopment\n\nJava modules are formatted with Spotless using the Google Java Style.  Use mvn spotless:apply to format sources and mvn verify to run the check.\n\nThe timeseries-python module relies on pre-commit with black and flake8 for formatting and linting:\n\n```bash\npip install pre-commit\npre-commit run --all-files\n```\n\nThe GitHub Actions workflow runs these tools on every push and pull request.\n\nRunning tests\n\nExecute the full test suite across all modules:\n\nJava modules\n\n```bash\nmvn verify\n```\n\nKotlin (Android)\n\n```bash\ncd android-app\n./gradlew test\nInstrumentation tests require an emulator:\n./gradlew connectedAndroidTest\n```\n\nPython\n\n```bash\ncd timeseries-python\npre-commit run --all-files\npip install -r requirements-test.txt\npytest --basetemp=.pytest_tmp\n```\n\nFrontend\n\n```bash\ncd ui\nnpm install\nnpm test\n```\n\nConfiguration\n\nThe Alphavantage feed requires one or more API keys supplied via the\nALPHAVANTAGE_API_KEYS environment variable. Provide a comma-separated\nlist and keep the values out of source control:\n\n```bash\nexport ALPHAVANTAGE_API_KEYS=key1,key2\n```\n\nMissing o",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/pension-risk-management-system"
+  },
+  {
+    "curated_note": "A real-time pitch-tracking practice tool for choir singers: a Windows desktop app (TypeScript/Electron\nfrontend) that tracks pitch against a MusicXML score using GPU or CPU pitch engines (CUDA/torchcrepe),\nstreamed over WebSocket. It's the one project here that's nothing to do with finance \u2014 a personal\ninterest (I sing) turned into a real-time systems problem worth solving properly.",
+    "description": "Practice your choir part. Hear the notes. Sing along. See your pitch in real time.",
+    "languages": [
+      "TypeScript",
+      "Python",
+      "HTML",
+      "JavaScript",
+      "CSS",
+      "Just",
+      "Shell"
+    ],
+    "name": "sing-attune",
+    "pushed_at": "2026-08-26",
+    "readme_excerpt": "sing-attune\n\nPractice your choir part. Hear the notes. Sing along. See your pitch in real time.\n\nSee ARCHITECTURE.md for the current module boundaries and\nthe working open-core classification.\n\nsing-attune plays your part from a MusicXML score through your headphones. You sing along. As you sing, your pitch appears live on the score \u2014 a moving dot over the notation, green when you're on it, red when you're not. No post-hoc analysis, no percentage scores. Just an honest mirror of what your voice is doing, in the moment, against what the music asks for.\n\nDemo\n\nDemo GIF is shared in the PR/release notes (kept out of the repository to avoid committing binary assets).\n\n---\n\nThe loop\n\n1. Load a MusicXML file (MuseScore, Sibelius, Finale, Audiveris)\n2. Select your part\n3. Press play \u2014 the score plays piano tones through your headphones\n4. Sing along\n5. Watch your pitch trace appear over the score in real time\n\nThat's it.\n\n---\n\nPitch graph panel\n\nThe UI now includes a dedicated pitch graph canvas under the toolbar:\n\n- Semitone grid from C2 to C6 with octave labels\n- Rolling 10-second time window with 1-second vertical grid lines\n- Continuous f0 trace colour-coded against the active target ",
+    "stars": 1,
+    "topics": [],
+    "url": "https://github.com/leonarduk/sing-attune"
+  },
+  {
+    "curated_note": null,
+    "description": "Provides common Terraform code for creating AWS components like Lambda functions",
+    "languages": [
+      "HCL"
+    ],
+    "name": "terraform-leonarduk-common",
+    "pushed_at": "2024-06-11",
+    "readme_excerpt": "terraform-leonarduk-common\nProvides common Terraform code for creating AWS components like Lambda functions\n\nhttps://developer.hashicorp.com/terraform/registry/modules/publish\n\nhttps://developer.hashicorp.com/terraform/language/modules/develop/structure",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/terraform-leonarduk-common"
+  },
+  {
+    "curated_note": null,
+    "description": "",
+    "languages": [
+      "HTML",
+      "Python",
+      "Shell",
+      "CSS"
+    ],
+    "name": "tomleonard",
+    "pushed_at": "2026-03-21",
+    "readme_excerpt": "tomleonard\n\nThis publishes to \nhttp://tomleonard.co.uk\n\nAll content owned by Tom Leonard Literary Estate",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/tomleonard"
+  },
+  {
+    "curated_note": null,
+    "description": "UNISoN is a Java-based NNTP client that can analyse messages to save to a Pajek-format file for Social Network Analysis. Developed as part of an MSc Business Systems Analysis & Design at City University. ",
+    "languages": [
+      "Java",
+      "Shell",
+      "Batchfile"
+    ],
+    "name": "unison",
+    "pushed_at": "2026-08-27",
+    "readme_excerpt": "unison\n\nUNISoN is a Java-based NNTP client that can analyse messages to save to a Pajek-format file for Social Network Analysis.\nDeveloped as part of an MSc Business Systems Analysis &amp; Design at City University.\n\nRun via Java web start - this is self-signed so you need to\nallow it\n\nTo run from source use the uk.co.sleonard.unison.UnisonMain class. The legacy DownloadNewsPanel.main remains for\ntesting.\n\nJust Go To *Startmenu >>Java >>Configure Java >> Security >> Edit site list >> Add >> \"http://unison.leonarduk.com/\" >>\nOK",
+    "stars": 6,
+    "topics": [],
+    "url": "https://github.com/leonarduk/unison"
+  },
+  {
+    "curated_note": null,
+    "description": "This contains code used by other projects to scrape from websites",
+    "languages": [
+      "Java",
+      "HTML",
+      "Shell"
+    ],
+    "name": "webscraper-core",
+    "pushed_at": "2026-08-22",
+    "readme_excerpt": "webscraper-core\n\nUsed by\n* leonarduk/pension-risk-management-system",
+    "stars": 0,
+    "topics": [],
+    "url": "https://github.com/leonarduk/webscraper-core"
+  }
+]

--- a/projects/08-linkedin-avatar/tests/test_build_github_snapshot.py
+++ b/projects/08-linkedin-avatar/tests/test_build_github_snapshot.py
@@ -1,0 +1,312 @@
+"""Tests for build/build_github_snapshot.py. No live GitHub API calls."""
+
+import json
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from build import build_github_snapshot as snap  # noqa: E402
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, json_data=None, text="", headers=None):
+        self.status_code = status_code
+        self._json_data = json_data
+        self.text = text
+        self.headers = headers or {}
+
+    def json(self):
+        return self._json_data
+
+
+def make_repo(name, **overrides):
+    repo = {
+        "name": name,
+        "owner": {"login": "leonarduk"},
+        "description": f"{name} description",
+        "html_url": f"https://github.com/leonarduk/{name}",
+        "topics": ["agents"],
+        "stargazers_count": 3,
+        "pushed_at": "2026-08-20T10:00:00Z",
+        "fork": False,
+        "archived": False,
+        "private": False,
+    }
+    repo.update(overrides)
+    return repo
+
+
+class TestFetchRepos:
+    def test_filters_forks_archived_and_private(self, monkeypatch):
+        repos = [
+            make_repo("keep-me"),
+            make_repo("a-fork", fork=True),
+            make_repo("an-archive", archived=True),
+            make_repo("a-private-repo", private=True),
+        ]
+
+        def fake_get(url, headers, params, timeout):
+            if params["page"] == 1:
+                return FakeResponse(200, json_data=repos)
+            return FakeResponse(200, json_data=[])
+
+        monkeypatch.setattr(snap.requests, "get", fake_get)
+
+        result = snap.fetch_repos("leonarduk")
+
+        assert [r["name"] for r in result] == ["keep-me"]
+
+    def test_paginates_until_short_page(self, monkeypatch):
+        page1 = [make_repo(f"repo-{i}") for i in range(100)]
+        page2 = [make_repo("repo-100")]
+        calls = []
+
+        def fake_get(url, headers, params, timeout):
+            calls.append(params["page"])
+            if params["page"] == 1:
+                return FakeResponse(200, json_data=page1)
+            if params["page"] == 2:
+                return FakeResponse(200, json_data=page2)
+            return FakeResponse(200, json_data=[])
+
+        monkeypatch.setattr(snap.requests, "get", fake_get)
+
+        result = snap.fetch_repos("leonarduk")
+
+        assert len(result) == 101
+        assert calls == [1, 2]
+
+    def test_rate_limit_raises(self, monkeypatch):
+        def fake_get(url, headers, params, timeout):
+            return FakeResponse(
+                403, json_data={}, headers={"X-RateLimit-Remaining": "0"}
+            )
+
+        monkeypatch.setattr(snap.requests, "get", fake_get)
+
+        with pytest.raises(snap.GitHubRateLimitError):
+            snap.fetch_repos("leonarduk")
+
+    def test_other_api_error_raises(self, monkeypatch):
+        def fake_get(url, headers, params, timeout):
+            return FakeResponse(500, json_data={})
+
+        monkeypatch.setattr(snap.requests, "get", fake_get)
+
+        with pytest.raises(snap.GitHubAPIError):
+            snap.fetch_repos("leonarduk")
+
+
+class TestFetchLanguages:
+    def test_orders_by_bytes_descending(self, monkeypatch):
+        def fake_get(url, headers, params, timeout):
+            return FakeResponse(
+                200, json_data={"Python": 100, "Shell": 500, "Dockerfile": 100}
+            )
+
+        monkeypatch.setattr(snap.requests, "get", fake_get)
+
+        result = snap.fetch_languages("leonarduk", "some-repo")
+
+        assert result == ["Shell", "Dockerfile", "Python"]
+
+    def test_missing_languages_returns_empty_list(self, monkeypatch):
+        def fake_get(url, headers, params, timeout):
+            return FakeResponse(404, json_data={})
+
+        monkeypatch.setattr(snap.requests, "get", fake_get)
+
+        assert snap.fetch_languages("leonarduk", "some-repo") == []
+
+
+class TestFetchReadme:
+    def test_returns_raw_text(self, monkeypatch):
+        def fake_get(url, headers, params, timeout):
+            return FakeResponse(200, text="# Title\n\nBody text.")
+
+        monkeypatch.setattr(snap.requests, "get", fake_get)
+
+        assert snap.fetch_readme("leonarduk", "some-repo") == "# Title\n\nBody text."
+
+    def test_missing_readme_returns_empty_string(self, monkeypatch):
+        def fake_get(url, headers, params, timeout):
+            return FakeResponse(404, text="")
+
+        monkeypatch.setattr(snap.requests, "get", fake_get)
+
+        assert snap.fetch_readme("leonarduk", "some-repo") == ""
+
+
+class TestStripMarkdown:
+    def test_strips_badges_links_headings_emphasis(self):
+        text = (
+            "![build](https://img.shields.io/badge.svg)\n"
+            "# Title\n\n"
+            "**Bold** and `code` and [a link](https://example.com).\n"
+            "<div>raw html</div>\n"
+        )
+        result = snap.strip_markdown(text)
+        assert "img.shields.io" not in result
+        assert "#" not in result
+        assert "**" not in result
+        assert "<div>" not in result
+        assert "a link" in result
+
+    def test_truncates_to_limit(self):
+        long_text = "word " * 1000
+        excerpt = snap.readme_excerpt(long_text, limit=50)
+        assert len(excerpt) == 50
+
+    @pytest.mark.parametrize(
+        "identifier",
+        [
+            "GITHUB_TOKEN",
+            "multi_agent_coder",
+            "other_var_names",
+        ],
+    )
+    def test_does_not_mangle_snake_case_identifiers(self, identifier):
+        result = snap.strip_markdown(f"Set the {identifier} environment variable.")
+        assert identifier in result
+
+
+class TestParseProjectsMd:
+    def test_parses_sections_into_notes(self, tmp_path):
+        path = tmp_path / "projects.md"
+        path.write_text(
+            "## issue-worm\n\nA multi-agent coder.\nSecond line.\n\n## allotmint\n\nA portfolio app.\n",
+            encoding="utf-8",
+        )
+
+        notes = snap.parse_projects_md(path)
+
+        assert notes["issue-worm"] == "A multi-agent coder.\nSecond line."
+        assert notes["allotmint"] == "A portfolio app."
+
+    def test_missing_file_returns_empty_dict(self, tmp_path):
+        assert snap.parse_projects_md(tmp_path / "does-not-exist.md") == {}
+
+
+class TestBuildSnapshot:
+    def _patch_all(self, monkeypatch, repos, languages=None, readme=""):
+        monkeypatch.setattr(snap, "fetch_repos", lambda user, token=None: repos)
+        monkeypatch.setattr(
+            snap, "fetch_languages", lambda owner, name, token=None: languages or []
+        )
+        monkeypatch.setattr(
+            snap, "fetch_readme", lambda owner, name, token=None: readme
+        )
+
+    def test_sorted_by_name(self, monkeypatch, tmp_path):
+        repos = [make_repo("zeta"), make_repo("alpha")]
+        self._patch_all(monkeypatch, repos)
+        empty_projects_md = tmp_path / "projects.md"
+
+        records = snap.build_snapshot("leonarduk", projects_md_path=empty_projects_md)
+
+        assert [r["name"] for r in records] == ["alpha", "zeta"]
+
+    def test_written_json_has_sorted_keys(self, monkeypatch, tmp_path):
+        repos = [make_repo("alpha")]
+        self._patch_all(monkeypatch, repos)
+        records = snap.build_snapshot(
+            "leonarduk", projects_md_path=tmp_path / "projects.md"
+        )
+        out_path = tmp_path / "github.json"
+
+        snap.write_snapshot(records, out_path)
+
+        raw_object_keys = list(
+            json.loads(out_path.read_text(encoding="utf-8"))[0].keys()
+        )
+        assert raw_object_keys == sorted(raw_object_keys)
+
+    def test_curated_note_merges_onto_matching_repo(self, monkeypatch, tmp_path):
+        repos = [make_repo("issue-worm"), make_repo("other-repo")]
+        self._patch_all(monkeypatch, repos)
+        projects_md = tmp_path / "projects.md"
+        projects_md.write_text(
+            "## issue-worm\n\nA multi-agent coder.\n", encoding="utf-8"
+        )
+
+        records = snap.build_snapshot("leonarduk", projects_md_path=projects_md)
+
+        by_name = {r["name"]: r for r in records}
+        assert by_name["issue-worm"]["curated_note"] == "A multi-agent coder."
+        assert by_name["other-repo"]["curated_note"] is None
+
+    def test_missing_readme_and_no_topics_does_not_crash(self, monkeypatch, tmp_path):
+        repos = [make_repo("bare-repo", topics=[], description=None)]
+        self._patch_all(monkeypatch, repos, readme="")
+
+        records = snap.build_snapshot(
+            "leonarduk", projects_md_path=tmp_path / "projects.md"
+        )
+
+        assert records[0]["topics"] == []
+        assert records[0]["description"] == ""
+        assert records[0]["readme_excerpt"] == ""
+
+    def test_pushed_at_truncated_to_date(self, monkeypatch, tmp_path):
+        repos = [make_repo("some-repo", pushed_at="2026-08-20T10:30:00Z")]
+        self._patch_all(monkeypatch, repos)
+
+        records = snap.build_snapshot(
+            "leonarduk", projects_md_path=tmp_path / "projects.md"
+        )
+
+        assert records[0]["pushed_at"] == "2026-08-20"
+
+
+class TestWriteSnapshot:
+    def test_deterministic_across_two_runs(self, tmp_path):
+        records = [{"name": "b"}, {"name": "a"}]
+        out_path = tmp_path / "github.json"
+
+        snap.write_snapshot(records, out_path)
+        first = out_path.read_text(encoding="utf-8")
+        snap.write_snapshot(records, out_path)
+        second = out_path.read_text(encoding="utf-8")
+
+        assert first == second
+
+    def test_never_writes_a_token(self, tmp_path):
+        records = [{"name": "a", "curated_note": None}]
+        out_path = tmp_path / "github.json"
+
+        snap.write_snapshot(records, out_path)
+
+        content = out_path.read_text(encoding="utf-8")
+        assert "ghp_" not in content
+        parsed = json.loads(content)
+        assert parsed == records
+
+
+class TestCli:
+    def test_rate_limit_error_exits_nonzero_without_writing(
+        self, monkeypatch, tmp_path
+    ):
+        def raise_rate_limit(user, token=None):
+            raise snap.GitHubRateLimitError("boom")
+
+        monkeypatch.setattr(snap, "build_snapshot", raise_rate_limit)
+        out_path = tmp_path / "github.json"
+
+        exit_code = snap.main(["--user", "leonarduk", "--out", str(out_path)])
+
+        assert exit_code == 1
+        assert not out_path.exists()
+
+    def test_happy_path_writes_file(self, monkeypatch, tmp_path):
+        monkeypatch.setattr(
+            snap, "build_snapshot", lambda user, token=None: [{"name": "a"}]
+        )
+        out_path = tmp_path / "github.json"
+
+        exit_code = snap.main(["--user", "leonarduk", "--out", str(out_path)])
+
+        assert exit_code == 0
+        assert out_path.exists()


### PR DESCRIPTION
## Summary
- `build/build_github_snapshot.py`: queries the GitHub REST API for `leonarduk`'s public, non-fork, non-archived repos and writes `knowledge/github.json` with one record per repo (`name`, `description`, `url`, `topics`, `languages`, `stars`, `pushed_at`, `readme_excerpt`, `curated_note`).
- Deterministic output: repos sorted by name, JSON keys sorted, `pushed_at` truncated to a date, README markdown stripped and excerpted to ~1200 chars.
- `curated_note` is merged in from `knowledge/projects.md`'s `## repo-name` sections (per the format #119 documented in the README), matched by exact repo name.
- Uses `GITHUB_TOKEN` from the environment when present, works unauthenticated otherwise.
- A rate-limit response or any other API error raises before any write — a failed run never leaves a partial `github.json`.
- Includes a real generated `knowledge/github.json` — I ran the script against the live API (unauthenticated) to produce the actual snapshot for all 15 current repos, not just the script.

Fixes #120

## Two bugs I caught while testing
1. My first markdown-stripping regex (`[*_\`]{1,3}`) stripped **any** underscore, backtick or asterisk, which mangled real identifiers in README text — `GITHUB_TOKEN` became `GITHUBTOKEN`, `multi_agent_coder` became `multiagentcoder`. I found this by eyeballing the actual generated `github.json`, not just the unit tests. Fixed by matching only paired emphasis/code delimiters (`**bold**`, `*italic*`, `` `code` ``) and leaving bare underscores/asterisks inside words alone — same principle as #118's "when ambiguous, don't touch it."
2. An early test asserted `build_snapshot()`'s in-memory dict keys were pre-sorted, which isn't actually a requirement — sorting happens at JSON-dump time in `write_snapshot()`. Fixed the test to check the written JSON instead.

## Test plan
- [x] `pytest projects/08-linkedin-avatar` — 77 passed: repo filtering (fork/archived/private), pagination, rate-limit and API-error handling, language ordering, README fetch (including 404), markdown stripping (including the identifier-mangling regression), `projects.md` note parsing and merging, missing-README/no-topics handling, `pushed_at` truncation, deterministic output, no-token-in-output, and CLI exit codes
- [x] No live API calls in tests — `requests.get` is monkeypatched throughout
- [x] Ran the real script against the live GitHub API and hand-checked the output: 15 repos, 4 curated notes merged onto the matching repos, no token or secret in the file
- [x] `black --check` and `flake8 --max-line-length=127` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)