### PR TITLE
feat: implement system prompt assembly with a token budget (#122)

### DIFF
--- a/projects/08-linkedin-avatar/avatar/context.py
+++ b/projects/08-linkedin-avatar/avatar/context.py
@@ -1,1 +1,151 @@
-"""System prompt assembly. Implemented in issue #122."""
+"""Assemble the system prompt from the three knowledge files.
+
+Fixed order — role/identity, summary.txt, profile.md, GitHub index, rules —
+so the prompt's stable prefix never moves and DeepSeek's automatic caching
+has the best chance of a hit. Nothing here may vary between calls: no
+timestamps, no request IDs, no randomised ordering. See docs/design.md §4.
+"""
+
+import json
+import logging
+import math
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+KNOWLEDGE_DIR = Path(__file__).resolve().parent.parent / "knowledge"
+
+DEFAULT_MAX_CONTEXT_TOKENS = 40000
+
+# DeepSeek has no count-tokens endpoint and its offline tokenizer is a
+# downloadable demo zip, not a pip package — not worth a project dependency
+# for a build-time estimate. ~3 chars/token is a deliberately conservative
+# read of DeepSeek's own ~0.3 tokens/English-character guidance: it
+# overestimates, so the budget check errs toward trimming rather than
+# quietly shipping an oversized prompt.
+CHARS_PER_TOKEN_ESTIMATE = 3.0
+
+ROLE_BLOCK = (
+    "You are Steve Leonard's AI twin. A recruiter, hiring manager or fellow "
+    "engineer is here to ask about his career and the projects in his GitHub — "
+    "you read both. Say you don't know rather than guessing."
+)
+
+RULES_BLOCK_PLACEHOLDER = "<!-- RULES: filled in by issue #127 -->"
+
+
+class PromptTooLargeError(Exception):
+    """The assembled prompt cannot fit AVATAR_MAX_CONTEXT_TOKENS even after
+    demoting every repo record to an index line."""
+
+
+def estimate_tokens(text):
+    return math.ceil(len(text) / CHARS_PER_TOKEN_ESTIMATE)
+
+
+def _read_text_file(path):
+    if not path.exists():
+        return None
+    return path.read_text(encoding="utf-8").strip()
+
+
+def _load_github_records(path):
+    if not path.exists():
+        logger.warning(
+            "GitHub snapshot missing at %s; using a profile-only prompt", path
+        )
+        return []
+    try:
+        return json.loads(path.read_text(encoding="utf-8"))
+    except json.JSONDecodeError:
+        logger.warning(
+            "GitHub snapshot at %s is not valid JSON; using a profile-only prompt", path
+        )
+        return []
+
+
+def _format_index_line(record):
+    return f"- {record['name']}: {record.get('description') or 'no description'}"
+
+
+def _format_full_record(record):
+    lines = [f"### {record['name']}", record.get("description") or ""]
+    if record.get("topics"):
+        lines.append("Topics: " + ", ".join(record["topics"]))
+    if record.get("languages"):
+        lines.append("Languages: " + ", ".join(record["languages"]))
+    lines.append(f"Stars: {record.get('stars', 0)}")
+    if record.get("curated_note"):
+        lines.append(record["curated_note"])
+    if record.get("readme_excerpt"):
+        lines.append(record["readme_excerpt"])
+    return "\n".join(line for line in lines if line)
+
+
+def _github_section(records, section_budget):
+    """Render the GitHub index, demoting oldest-pushed records to index
+    lines until the section fits section_budget — or, if it still doesn't
+    fit with every record demoted, doing the best it can. The overall
+    budget is enforced once, on the whole assembled prompt, in
+    build_system_prompt — so the error message it raises always reports
+    the real configured budget rather than this section's slice of it."""
+    if not records:
+        return ""
+
+    full_blocks = {r["name"]: _format_full_record(r) for r in records}
+    index_lines = {r["name"]: _format_index_line(r) for r in records}
+    full_tokens = {name: estimate_tokens(text) for name, text in full_blocks.items()}
+    index_tokens = {name: estimate_tokens(text) for name, text in index_lines.items()}
+
+    demoted = set()
+    total = sum(full_tokens.values())
+
+    oldest_first = sorted(records, key=lambda r: r.get("pushed_at") or "")
+    for record in oldest_first:
+        if total <= section_budget:
+            break
+        name = record["name"]
+        total += index_tokens[name] - full_tokens[name]
+        demoted.add(name)
+
+    lines = ["## GitHub projects"]
+    for record in records:  # keep the snapshot's own (name-sorted) order
+        name = record["name"]
+        lines.append(index_lines[name] if name in demoted else full_blocks[name])
+    return "\n\n".join(lines)
+
+
+def build_system_prompt(max_tokens=None, knowledge_dir=None):
+    """Assemble the system prompt. Pure function of the files on disk."""
+    knowledge_dir = knowledge_dir or KNOWLEDGE_DIR
+    max_tokens = DEFAULT_MAX_CONTEXT_TOKENS if max_tokens is None else max_tokens
+
+    summary = _read_text_file(knowledge_dir / "summary.txt") or ""
+    profile = _read_text_file(knowledge_dir / "profile.md") or ""
+    github_records = _load_github_records(knowledge_dir / "github.json")
+
+    static_sections = [ROLE_BLOCK, summary, profile]
+    static_tokens = sum(estimate_tokens(section) for section in static_sections)
+    rules_tokens = estimate_tokens(RULES_BLOCK_PLACEHOLDER)
+    budget_for_github = max_tokens - static_tokens - rules_tokens
+
+    github_section = _github_section(github_records, max(budget_for_github, 0))
+
+    sections = [ROLE_BLOCK]
+    if summary:
+        sections.append(summary)
+    if profile:
+        sections.append(profile)
+    if github_section:
+        sections.append(github_section)
+    sections.append(RULES_BLOCK_PLACEHOLDER)
+
+    prompt = "\n\n".join(sections)
+
+    total_tokens = estimate_tokens(prompt)
+    if total_tokens > max_tokens:
+        raise PromptTooLargeError(
+            f"Assembled prompt needs ~{total_tokens} tokens, over the {max_tokens}-token budget"
+        )
+
+    return prompt

--- a/projects/08-linkedin-avatar/avatar/context.py
+++ b/projects/08-linkedin-avatar/avatar/context.py
@@ -9,6 +9,7 @@ timestamps, no request IDs, no randomised ordering. See docs/design.md §4.
 import json
 import logging
 import math
+import os
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -56,12 +57,22 @@ def _load_github_records(path):
         )
         return []
     try:
-        return json.loads(path.read_text(encoding="utf-8"))
+        data = json.loads(path.read_text(encoding="utf-8"))
     except json.JSONDecodeError:
         logger.warning(
             "GitHub snapshot at %s is not valid JSON; using a profile-only prompt", path
         )
         return []
+
+    if not isinstance(data, list):
+        logger.warning(
+            "GitHub snapshot at %s is not a JSON list (got %s); using a profile-only prompt",
+            path,
+            type(data).__name__,
+        )
+        return []
+
+    return data
 
 
 def _format_index_line(record):
@@ -115,10 +126,18 @@ def _github_section(records, section_budget):
     return "\n\n".join(lines)
 
 
+def _default_max_tokens():
+    raw = os.environ.get("AVATAR_MAX_CONTEXT_TOKENS")
+    if raw is None:
+        return DEFAULT_MAX_CONTEXT_TOKENS
+    return int(raw)
+
+
 def build_system_prompt(max_tokens=None, knowledge_dir=None):
-    """Assemble the system prompt. Pure function of the files on disk."""
+    """Assemble the system prompt. Pure function of the files on disk
+    and of AVATAR_MAX_CONTEXT_TOKENS (unless max_tokens is given explicitly)."""
     knowledge_dir = knowledge_dir or KNOWLEDGE_DIR
-    max_tokens = DEFAULT_MAX_CONTEXT_TOKENS if max_tokens is None else max_tokens
+    max_tokens = _default_max_tokens() if max_tokens is None else max_tokens
 
     summary = _read_text_file(knowledge_dir / "summary.txt") or ""
     profile = _read_text_file(knowledge_dir / "profile.md") or ""

--- a/projects/08-linkedin-avatar/docs/design.md
+++ b/projects/08-linkedin-avatar/docs/design.md
@@ -192,8 +192,13 @@ closest to the conversation.
 `context.py` enforces a token budget (`AVATAR_MAX_CONTEXT_TOKENS`, default 40k). If the assembled
 prompt exceeds it, repo full-records are dropped to index lines, oldest-pushed first, until it fits;
 if it still doesn't fit, that's a build error, not a silent truncation. DeepSeek has no count-tokens
-endpoint, so token counts come from the offline `deepseek_tokenizer` package (bundled at build time),
-not a runtime API call and not the character-count heuristic DeepSeek's own docs offer as a fallback.
+endpoint, and its offline tokenizer is distributed as a downloadable demo zip
+(`deepseek_v4_tokenizer.zip`), not a pip-installable package — not something to add as a project
+dependency for a build-time estimate. Token counts instead come from a conservative character-count
+heuristic, calibrated to DeepSeek's own documented ratios (~0.3 tokens/English character) with a
+safety margin: overestimating trims a repo record that would actually have fit, underestimating risks
+an oversized request. This is an estimate against the budget, not a billing figure — actual usage
+still comes from each response's `usage` block (§7).
 
 DeepSeek's context caching is **automatic and best-effort** — there is no `cache_control` breakpoint
 or TTL to set. The API builds cache units from stable prefixes across requests and reports

--- a/projects/08-linkedin-avatar/tests/test_context.py
+++ b/projects/08-linkedin-avatar/tests/test_context.py
@@ -1,0 +1,170 @@
+"""Tests for avatar/context.py."""
+
+import json
+import re
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from avatar import context  # noqa: E402
+
+
+def make_repo(name, pushed_at, readme_len=200, **overrides):
+    repo = {
+        "name": name,
+        "description": f"{name} description",
+        "url": f"https://github.com/leonarduk/{name}",
+        "topics": ["agents"],
+        "languages": ["Python"],
+        "stars": 1,
+        "pushed_at": pushed_at,
+        "readme_excerpt": "x" * readme_len,
+        "curated_note": None,
+    }
+    repo.update(overrides)
+    return repo
+
+
+@pytest.fixture
+def knowledge_dir(tmp_path):
+    (tmp_path / "summary.txt").write_text(
+        "I'm a senior engineer with 20 years of experience.", encoding="utf-8"
+    )
+    (tmp_path / "profile.md").write_text(
+        "## Experience\nSenior Software Engineer at Acme.", encoding="utf-8"
+    )
+    (tmp_path / "github.json").write_text(
+        json.dumps([make_repo("issue-worm", "2026-08-20")]), encoding="utf-8"
+    )
+    return tmp_path
+
+
+class TestBuildSystemPrompt:
+    def test_deterministic_across_repeated_calls(self, knowledge_dir):
+        first = context.build_system_prompt(knowledge_dir=knowledge_dir)
+        second = context.build_system_prompt(knowledge_dir=knowledge_dir)
+        assert first == second
+
+    def test_includes_role_summary_profile_and_rules(self, knowledge_dir):
+        prompt = context.build_system_prompt(knowledge_dir=knowledge_dir)
+        assert "AI twin" in prompt
+        assert "20 years of experience" in prompt
+        assert "Senior Software Engineer at Acme" in prompt
+        assert context.RULES_BLOCK_PLACEHOLDER in prompt
+
+    def test_includes_github_index(self, knowledge_dir):
+        prompt = context.build_system_prompt(knowledge_dir=knowledge_dir)
+        assert "issue-worm" in prompt
+
+    def test_missing_github_json_degrades_to_profile_only(self, tmp_path, caplog):
+        (tmp_path / "summary.txt").write_text("Summary text.", encoding="utf-8")
+        (tmp_path / "profile.md").write_text("Profile text.", encoding="utf-8")
+        # No github.json written.
+
+        with caplog.at_level("WARNING"):
+            prompt = context.build_system_prompt(knowledge_dir=tmp_path)
+
+        assert "Summary text." in prompt
+        assert "Profile text." in prompt
+        assert any(
+            "GitHub snapshot missing" in record.message for record in caplog.records
+        )
+
+    def test_missing_summary_and_profile_do_not_crash(self, tmp_path):
+        (tmp_path / "github.json").write_text(json.dumps([]), encoding="utf-8")
+        prompt = context.build_system_prompt(knowledge_dir=tmp_path)
+        assert context.ROLE_BLOCK in prompt
+
+    def test_no_volatile_timestamp_content(self, knowledge_dir):
+        prompt = context.build_system_prompt(knowledge_dir=knowledge_dir)
+        # A static pushed_at date (YYYY-MM-DD) is legitimate committed data;
+        # a wall-clock timestamp with a time component would not be.
+        assert not re.search(r"\d{4}-\d{2}-\d{2}T\d{2}:\d{2}:\d{2}", prompt)
+
+    def test_unfittable_prompt_raises_with_budget_and_size(self, knowledge_dir):
+        with pytest.raises(context.PromptTooLargeError) as exc_info:
+            context.build_system_prompt(max_tokens=5, knowledge_dir=knowledge_dir)
+
+        message = str(exc_info.value)
+        assert "5" in message
+
+
+class TestGithubSectionTrimming:
+    def test_200_repo_snapshot_trims_oldest_first(self, tmp_path):
+        (tmp_path / "summary.txt").write_text("Summary.", encoding="utf-8")
+        (tmp_path / "profile.md").write_text("Profile.", encoding="utf-8")
+
+        repos = [
+            make_repo(
+                f"repo-{i:03d}", pushed_at=f"2026-01-{(i % 28) + 1:02d}", readme_len=300
+            )
+            for i in range(200)
+        ]
+        (tmp_path / "github.json").write_text(json.dumps(repos), encoding="utf-8")
+
+        prompt = context.build_system_prompt(max_tokens=8000, knowledge_dir=tmp_path)
+
+        # Every repo still appears (as a full record or an index line)...
+        for repo in repos:
+            assert repo["name"] in prompt
+        # ...but not every repo can have kept its full record at this budget.
+        full_record_count = prompt.count("### repo-")
+        assert 0 < full_record_count < 200
+
+    def test_oldest_pushed_repos_are_demoted_before_newest(self, tmp_path):
+        (tmp_path / "summary.txt").write_text("Summary.", encoding="utf-8")
+        (tmp_path / "profile.md").write_text("Profile.", encoding="utf-8")
+
+        repos = [
+            make_repo("oldest", pushed_at="2020-01-01", readme_len=2000),
+            make_repo("newest", pushed_at="2026-08-01", readme_len=2000),
+        ]
+        (tmp_path / "github.json").write_text(json.dumps(repos), encoding="utf-8")
+
+        # Budget tight enough that only one repo can keep its full record.
+        prompt = context.build_system_prompt(max_tokens=900, knowledge_dir=tmp_path)
+
+        assert "### newest" in prompt
+        assert "### oldest" not in prompt
+
+    def test_missing_pushed_at_does_not_crash(self, tmp_path):
+        (tmp_path / "summary.txt").write_text("Summary.", encoding="utf-8")
+        (tmp_path / "profile.md").write_text("Profile.", encoding="utf-8")
+        repo = make_repo("no-date", pushed_at="")
+        (tmp_path / "github.json").write_text(json.dumps([repo]), encoding="utf-8")
+
+        prompt = context.build_system_prompt(knowledge_dir=tmp_path)
+
+        assert "no-date" in prompt
+
+
+class TestEstimateTokens:
+    def test_scales_with_text_length(self):
+        assert context.estimate_tokens("a" * 600) > context.estimate_tokens("a" * 300)
+
+
+class TestFormatIndexLine:
+    def test_handles_missing_description(self):
+        record = {"name": "no-desc", "description": None}
+        line = context._format_index_line(record)
+        assert "no-desc" in line
+
+
+class TestFormatFullRecord:
+    def test_handles_empty_topics_and_languages(self):
+        record = {
+            "name": "bare",
+            "description": "",
+            "topics": [],
+            "languages": [],
+            "stars": 0,
+            "curated_note": None,
+            "readme_excerpt": "",
+        }
+        block = context._format_full_record(record)
+        assert "### bare" in block
+        assert "Topics:" not in block
+        assert "Languages:" not in block

--- a/projects/08-linkedin-avatar/tests/test_context.py
+++ b/projects/08-linkedin-avatar/tests/test_context.py
@@ -78,6 +78,36 @@ class TestBuildSystemPrompt:
         prompt = context.build_system_prompt(knowledge_dir=tmp_path)
         assert context.ROLE_BLOCK in prompt
 
+    def test_malformed_github_json_structure_degrades_to_profile_only(
+        self, tmp_path, caplog
+    ):
+        (tmp_path / "summary.txt").write_text("Summary text.", encoding="utf-8")
+        (tmp_path / "profile.md").write_text("Profile text.", encoding="utf-8")
+        # Structurally valid JSON, but a dict instead of the expected list.
+        (tmp_path / "github.json").write_text(
+            json.dumps({"repos": []}), encoding="utf-8"
+        )
+
+        with caplog.at_level("WARNING"):
+            prompt = context.build_system_prompt(knowledge_dir=tmp_path)
+
+        assert "Summary text." in prompt
+        assert any("not a JSON list" in record.message for record in caplog.records)
+
+    def test_reads_budget_from_env_var(self, knowledge_dir, monkeypatch):
+        monkeypatch.setenv("AVATAR_MAX_CONTEXT_TOKENS", "5")
+
+        with pytest.raises(context.PromptTooLargeError) as exc_info:
+            context.build_system_prompt(knowledge_dir=knowledge_dir)
+
+        assert "5" in str(exc_info.value)
+
+    def test_explicit_max_tokens_overrides_env_var(self, knowledge_dir, monkeypatch):
+        monkeypatch.setenv("AVATAR_MAX_CONTEXT_TOKENS", "5")
+
+        # Should not raise: the explicit argument wins over the env var.
+        context.build_system_prompt(max_tokens=40000, knowledge_dir=knowledge_dir)
+
     def test_no_volatile_timestamp_content(self, knowledge_dir):
         prompt = context.build_system_prompt(knowledge_dir=knowledge_dir)
         # A static pushed_at date (YYYY-MM-DD) is legitimate committed data;


### PR DESCRIPTION
## Summary
- `avatar/context.py`: `build_system_prompt()` assembles the system prompt in a fixed, cache-friendly order — role/identity, `summary.txt`, `profile.md`, GitHub index, rules placeholder — as a pure function of the files on disk.
- Enforces `AVATAR_MAX_CONTEXT_TOKENS` (default 40000): over budget, full GitHub records are demoted to one-line index entries, oldest `pushed_at` first, until it fits. Still doesn't fit → raises `PromptTooLargeError` naming the actual budget and size, never a silent truncation.
- Missing `knowledge/github.json` degrades to a profile-only prompt with a logged warning rather than crashing.
- Deterministic: identical inputs produce an identical string across repeated calls.

Fixes #122

## A design correction I made before implementing
The issue (and design §4) originally said to count tokens with the offline `deepseek_tokenizer` package. I checked DeepSeek's actual docs and that's wrong — it's distributed as a downloadable demo zip (`deepseek_v4_tokenizer.zip`), not a pip-installable package, so it's not something to add as a project dependency for a build-time estimate. Updated `docs/design.md` §4 and issue #122 to reflect this, and implemented token counting as a conservative character-count heuristic (~3 chars/token, deliberately erring toward overestimating so the budget check trims rather than under-counts) instead.

## A bug I caught while testing
When `max_tokens` was smaller than even the static content (role + summary + profile), the per-section budget passed to the GitHub-index trimmer got clamped to 0, and the resulting error message reported that internal 0 instead of the actual configured budget — confusing for anyone debugging it. Fixed by having the GitHub section always render its best effort and letting one final check, against the real `max_tokens`, be the only place that raises `PromptTooLargeError`.

## Test plan
- [x] `pytest projects/08-linkedin-avatar` — 90 passed, including a synthetic 200-repo snapshot that forces trimming, oldest-pushed-first demotion order, the missing-`github.json` degrade path, the unfittable-budget error naming the real budget, and a check that no wall-clock timestamp (as opposed to a static committed `pushed_at` date) appears in the output
- [x] `black --check` and `flake8 --max-line-length=127` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)