### PR TITLE
feat: implement the DeepSeek client and tool-use loop (#124)

### DIFF
--- a/projects/08-linkedin-avatar/avatar/llm.py
+++ b/projects/08-linkedin-avatar/avatar/llm.py
@@ -1,1 +1,155 @@
-"""DeepSeek client and tool-use loop. Implemented in issue #124."""
+"""DeepSeek client and tool-use loop.
+
+DeepSeek's API is OpenAI-compatible, so this uses the `openai` SDK pointed at
+DeepSeek's base URL rather than the Anthropic SDK. Caching is automatic on
+DeepSeek's side (design §4) — there's nothing to configure here, only usage
+to log so real cache behaviour is visible. See docs/design.md §7.
+"""
+
+import json
+import logging
+import os
+
+from openai import APIConnectionError, APIStatusError, OpenAI, RateLimitError
+
+from avatar import tools
+
+logger = logging.getLogger(__name__)
+
+# Strict-mode tool schemas (design §5 / issue #123) are a DeepSeek beta
+# feature gated behind the /beta base URL.
+DEEPSEEK_BASE_URL = "https://api.deepseek.com/beta"
+DEFAULT_MODEL = "deepseek-v4-flash"
+
+MAX_REPLY_TOKENS = 1024
+MAX_TOOL_LOOP_ITERATIONS = 5
+
+FRIENDLY_RATE_LIMIT_MESSAGE = (
+    "My twin is getting a lot of questions right now — please try again in a moment."
+)
+FRIENDLY_ERROR_MESSAGE = "Something went wrong on my end. Please try again, or reach Steve directly via LinkedIn."
+
+
+def _build_client(api_key=None):
+    api_key = api_key or os.environ["DEEPSEEK_API_KEY"]
+    return OpenAI(base_url=DEEPSEEK_BASE_URL, api_key=api_key)
+
+
+def _model():
+    return os.environ.get("AVATAR_MODEL", DEFAULT_MODEL)
+
+
+def _empty_usage():
+    return {
+        "input_tokens": 0,
+        "output_tokens": 0,
+        "cache_hit_tokens": 0,
+        "cache_miss_tokens": 0,
+    }
+
+
+def _accumulate_usage(totals, usage):
+    """Fold one response's usage into the running totals and log it, so real
+    cache behaviour (hit vs. miss) is visible rather than assumed."""
+    if usage is None:
+        return
+
+    prompt_tokens = getattr(usage, "prompt_tokens", 0) or 0
+    completion_tokens = getattr(usage, "completion_tokens", 0) or 0
+    cache_hit = getattr(usage, "prompt_cache_hit_tokens", 0) or 0
+    cache_miss = getattr(usage, "prompt_cache_miss_tokens", None)
+    if cache_miss is None:
+        cache_miss = max(prompt_tokens - cache_hit, 0)
+
+    totals["input_tokens"] += prompt_tokens
+    totals["output_tokens"] += completion_tokens
+    totals["cache_hit_tokens"] += cache_hit
+    totals["cache_miss_tokens"] += cache_miss
+
+    logger.info(
+        "DeepSeek usage: prompt=%s completion=%s cache_hit=%s cache_miss=%s",
+        prompt_tokens,
+        completion_tokens,
+        cache_hit,
+        cache_miss,
+    )
+
+
+def _tool_call_message(message, tool_calls):
+    return {
+        "role": "assistant",
+        "content": message.content,
+        "tool_calls": [
+            {
+                "id": call.id,
+                "type": "function",
+                "function": {
+                    "name": call.function.name,
+                    "arguments": call.function.arguments,
+                },
+            }
+            for call in tool_calls
+        ],
+    }
+
+
+def _dispatch_tool_call(call):
+    try:
+        arguments = json.loads(call.function.arguments)
+    except json.JSONDecodeError:
+        logger.exception("Bad JSON arguments for tool call %s", call.function.name)
+        result = {"error": "invalid tool arguments"}
+    else:
+        result = tools.dispatch(call.function.name, arguments)
+
+    return {
+        "role": "tool",
+        "tool_call_id": call.id,
+        "content": json.dumps(result),
+    }
+
+
+def send_message(conversation, system_prompt, api_key=None, client=None):
+    """Send a conversation to DeepSeek, running the tool-use loop to
+    completion. `conversation` is a list of {"role", "content"} messages,
+    excluding the system prompt. Returns (reply_text, usage_totals)."""
+    client = client or _build_client(api_key)
+    model = _model()
+    messages = [{"role": "system", "content": system_prompt}] + list(conversation)
+    usage_totals = _empty_usage()
+
+    for _ in range(MAX_TOOL_LOOP_ITERATIONS):
+        try:
+            response = client.chat.completions.create(
+                model=model,
+                messages=messages,
+                tools=tools.TOOL_DEFINITIONS,
+                max_tokens=MAX_REPLY_TOKENS,
+            )
+        except RateLimitError:
+            logger.exception("DeepSeek rate limit hit")
+            return FRIENDLY_RATE_LIMIT_MESSAGE, usage_totals
+        except APIStatusError:
+            logger.exception("DeepSeek API returned an error status")
+            return FRIENDLY_ERROR_MESSAGE, usage_totals
+        except APIConnectionError:
+            logger.exception("Could not connect to DeepSeek")
+            return FRIENDLY_ERROR_MESSAGE, usage_totals
+
+        _accumulate_usage(usage_totals, response.usage)
+
+        message = response.choices[0].message
+        tool_calls = getattr(message, "tool_calls", None)
+
+        if not tool_calls:
+            return message.content or "", usage_totals
+
+        messages.append(_tool_call_message(message, tool_calls))
+        for call in tool_calls:
+            messages.append(_dispatch_tool_call(call))
+
+    logger.warning(
+        "Tool loop exceeded %s iterations without a final answer",
+        MAX_TOOL_LOOP_ITERATIONS,
+    )
+    return FRIENDLY_ERROR_MESSAGE, usage_totals

--- a/projects/08-linkedin-avatar/tests/test_llm.py
+++ b/projects/08-linkedin-avatar/tests/test_llm.py
@@ -1,0 +1,273 @@
+"""Tests for avatar/llm.py. No live DeepSeek/OpenAI API calls."""
+
+import json
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+import httpx
+import pytest
+from openai import APIConnectionError, APIStatusError, RateLimitError
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from avatar import llm  # noqa: E402
+
+
+def make_usage(prompt_tokens=100, completion_tokens=20, cache_hit=0, cache_miss=None):
+    if cache_miss is None:
+        cache_miss = prompt_tokens - cache_hit
+    return SimpleNamespace(
+        prompt_tokens=prompt_tokens,
+        completion_tokens=completion_tokens,
+        prompt_cache_hit_tokens=cache_hit,
+        prompt_cache_miss_tokens=cache_miss,
+    )
+
+
+def make_tool_call(call_id, name, arguments):
+    return SimpleNamespace(
+        id=call_id,
+        function=SimpleNamespace(name=name, arguments=json.dumps(arguments)),
+    )
+
+
+def make_response(content=None, tool_calls=None, usage=None):
+    message = SimpleNamespace(content=content, tool_calls=tool_calls)
+    return SimpleNamespace(
+        choices=[SimpleNamespace(message=message)], usage=usage or make_usage()
+    )
+
+
+class FakeClient:
+    """Records every create() call and returns queued responses in order."""
+
+    def __init__(self, responses):
+        self._responses = list(responses)
+        self.calls = []
+
+        class _Completions:
+            def create(inner_self, **kwargs):
+                self.calls.append(kwargs)
+                if not self._responses:
+                    raise AssertionError("FakeClient ran out of queued responses")
+                response = self._responses.pop(0)
+                if isinstance(response, Exception):
+                    raise response
+                return response
+
+        self.chat = SimpleNamespace(completions=_Completions())
+
+
+class TestSendMessageHappyPath:
+    def test_single_response_with_no_tool_calls(self):
+        client = FakeClient([make_response(content="Hello there.")])
+
+        reply, usage = llm.send_message(
+            [{"role": "user", "content": "hi"}], "system", client=client
+        )
+
+        assert reply == "Hello there."
+        assert len(client.calls) == 1
+
+    def test_two_round_tool_conversation_completes(self):
+        tool_call = make_tool_call("call_1", "lookup_project", {"name": "issue-worm"})
+        client = FakeClient(
+            [
+                make_response(tool_calls=[tool_call]),
+                make_response(content="issue-worm is a multi-agent coder."),
+            ]
+        )
+
+        reply, usage = llm.send_message(
+            [{"role": "user", "content": "tell me about issue-worm"}],
+            "system",
+            client=client,
+        )
+
+        assert reply == "issue-worm is a multi-agent coder."
+        assert len(client.calls) == 2
+        # The second call's messages must include the assistant tool_calls
+        # message and a matching tool-result message.
+        second_call_messages = client.calls[1]["messages"]
+        roles = [m["role"] for m in second_call_messages]
+        assert "tool" in roles
+        tool_message = next(m for m in second_call_messages if m["role"] == "tool")
+        assert tool_message["tool_call_id"] == "call_1"
+
+    def test_multiple_tool_calls_in_one_response_all_get_matching_results(self):
+        call_a = make_tool_call("call_a", "record_unknown_question", {"question": "q1"})
+        call_b = make_tool_call("call_b", "record_unknown_question", {"question": "q2"})
+        client = FakeClient(
+            [
+                make_response(tool_calls=[call_a, call_b]),
+                make_response(content="done"),
+            ]
+        )
+
+        reply, usage = llm.send_message(
+            [{"role": "user", "content": "hi"}], "system", client=client
+        )
+
+        assert reply == "done"
+        second_call_messages = client.calls[1]["messages"]
+        tool_messages = [m for m in second_call_messages if m["role"] == "tool"]
+        assert {m["tool_call_id"] for m in tool_messages} == {"call_a", "call_b"}
+
+    def test_bad_json_tool_arguments_does_not_crash(self):
+        bad_call = SimpleNamespace(
+            id="call_bad",
+            function=SimpleNamespace(name="lookup_project", arguments="{not json"),
+        )
+        client = FakeClient(
+            [
+                make_response(tool_calls=[bad_call]),
+                make_response(content="handled"),
+            ]
+        )
+
+        reply, usage = llm.send_message(
+            [{"role": "user", "content": "hi"}], "system", client=client
+        )
+
+        assert reply == "handled"
+        tool_message = next(
+            m for m in client.calls[1]["messages"] if m["role"] == "tool"
+        )
+        assert "error" in json.loads(tool_message["content"])
+
+
+class TestUsageAccounting:
+    def test_usage_accumulated_across_rounds(self):
+        tool_call = make_tool_call(
+            "call_1", "record_unknown_question", {"question": "q"}
+        )
+        client = FakeClient(
+            [
+                make_response(
+                    tool_calls=[tool_call],
+                    usage=make_usage(
+                        prompt_tokens=100, completion_tokens=10, cache_hit=20
+                    ),
+                ),
+                make_response(
+                    content="done",
+                    usage=make_usage(
+                        prompt_tokens=150, completion_tokens=15, cache_hit=140
+                    ),
+                ),
+            ]
+        )
+
+        _, usage = llm.send_message(
+            [{"role": "user", "content": "hi"}], "system", client=client
+        )
+
+        assert usage["input_tokens"] == 250
+        assert usage["output_tokens"] == 25
+        assert usage["cache_hit_tokens"] == 160
+
+    def test_usage_returned_even_on_single_call(self):
+        client = FakeClient(
+            [
+                make_response(
+                    content="hi", usage=make_usage(prompt_tokens=50, cache_hit=10)
+                )
+            ]
+        )
+
+        _, usage = llm.send_message([], "system", client=client)
+
+        assert usage["input_tokens"] == 50
+        assert usage["cache_hit_tokens"] == 10
+
+
+class TestErrorHandling:
+    def _rate_limit_error(self):
+        response = httpx.Response(
+            429, request=httpx.Request("POST", "https://api.deepseek.com")
+        )
+        return RateLimitError("rate limited", response=response, body=None)
+
+    def _status_error(self):
+        response = httpx.Response(
+            500, request=httpx.Request("POST", "https://api.deepseek.com")
+        )
+        return APIStatusError("server error", response=response, body=None)
+
+    def _connection_error(self):
+        return APIConnectionError(
+            request=httpx.Request("POST", "https://api.deepseek.com")
+        )
+
+    def test_rate_limit_returns_friendly_message(self):
+        client = FakeClient([self._rate_limit_error()])
+        reply, usage = llm.send_message([], "system", client=client)
+        assert reply == llm.FRIENDLY_RATE_LIMIT_MESSAGE
+
+    def test_status_error_returns_friendly_message(self):
+        client = FakeClient([self._status_error()])
+        reply, usage = llm.send_message([], "system", client=client)
+        assert reply == llm.FRIENDLY_ERROR_MESSAGE
+
+    def test_connection_error_returns_friendly_message(self):
+        client = FakeClient([self._connection_error()])
+        reply, usage = llm.send_message([], "system", client=client)
+        assert reply == llm.FRIENDLY_ERROR_MESSAGE
+
+    def test_errors_never_raise_out_of_send_message(self):
+        client = FakeClient([self._rate_limit_error()])
+        # Should not raise.
+        llm.send_message([], "system", client=client)
+
+
+class TestToolLoopTermination:
+    def test_hard_cap_stops_infinite_tool_loop(self):
+        endless_tool_call = make_tool_call(
+            "call_x", "record_unknown_question", {"question": "q"}
+        )
+        responses = [
+            make_response(tool_calls=[endless_tool_call])
+            for _ in range(llm.MAX_TOOL_LOOP_ITERATIONS)
+        ]
+        client = FakeClient(responses)
+
+        reply, usage = llm.send_message(
+            [{"role": "user", "content": "hi"}], "system", client=client
+        )
+
+        assert reply == llm.FRIENDLY_ERROR_MESSAGE
+        assert len(client.calls) == llm.MAX_TOOL_LOOP_ITERATIONS
+
+
+class TestBuildClient:
+    def test_reads_api_key_from_env_only(self, monkeypatch):
+        monkeypatch.setenv("DEEPSEEK_API_KEY", "test-key-123")
+        captured = {}
+
+        class FakeOpenAI:
+            def __init__(self, base_url, api_key):
+                captured["base_url"] = base_url
+                captured["api_key"] = api_key
+
+        monkeypatch.setattr(llm, "OpenAI", FakeOpenAI)
+
+        llm._build_client()
+
+        assert captured["api_key"] == "test-key-123"
+        assert captured["base_url"] == llm.DEEPSEEK_BASE_URL
+
+    def test_missing_api_key_raises(self, monkeypatch):
+        monkeypatch.delenv("DEEPSEEK_API_KEY", raising=False)
+        with pytest.raises(KeyError):
+            llm._build_client()
+
+
+class TestModelSelection:
+    def test_defaults_to_deepseek_v4_flash(self, monkeypatch):
+        monkeypatch.delenv("AVATAR_MODEL", raising=False)
+        assert llm._model() == llm.DEFAULT_MODEL
+
+    def test_reads_avatar_model_env_var(self, monkeypatch):
+        monkeypatch.setenv("AVATAR_MODEL", "deepseek-v4-pro")
+        assert llm._model() == "deepseek-v4-pro"


### PR DESCRIPTION
## Summary
- `avatar/llm.py`: `send_message(conversation, system_prompt, api_key=None, client=None)` uses the `openai` SDK pointed at DeepSeek's `/beta` base URL (required for the strict-mode tool schemas from #123) and runs the tool-use loop to completion.
- Every `tool_calls` entry in a response is dispatched via `avatar.tools.dispatch`, with one matching `role: "tool"` message per call, each carrying its own `tool_call_id`.
- Usage (input, output, and DeepSeek's `prompt_cache_hit_tokens`/`prompt_cache_miss_tokens`) is accumulated across rounds and logged, so real cache behaviour is visible once deployed rather than assumed.
- `RateLimitError`, `APIStatusError`, `APIConnectionError` (most-specific-first, since `RateLimitError` subclasses `APIStatusError`) all degrade to a friendly message instead of a traceback reaching the visitor.
- A hard 5-iteration cap (`MAX_TOOL_LOOP_ITERATIONS`) stops a runaway tool loop with a graceful message rather than looping forever.
- `client` is injectable for testing; production code builds it from `DEEPSEEK_API_KEY` (env-only, never a literal).

Fixes #124

## Before writing this, I verified the openai SDK's actual behavior rather than assuming
- Confirmed `RateLimitError`'s MRO (`RateLimitError → APIStatusError → APIError → OpenAIError`) and that `APIConnectionError` is a sibling, not a subclass — so the except-order in the issue (rate limit, status, connection) is correct as specified.
- Confirmed `CompletionUsage`'s pydantic model has `extra="allow"`, so DeepSeek's vendor-specific `prompt_cache_hit_tokens`/`prompt_cache_miss_tokens` fields are reachable via plain `getattr` on the usage object without any special handling.
- Constructed real `openai.RateLimitError`/`APIStatusError`/`APIConnectionError` instances in tests (via `httpx.Response`/`httpx.Request`) rather than mocking generic exceptions, so the except-clauses are exercised against the real exception types.

## Test plan
- [x] `pytest projects/08-linkedin-avatar` — 108 passed, including: a two-round tool conversation, multiple tool_calls in one response each getting a matching `tool_call_id`, usage accumulation across rounds, all three error types returning their friendly message without raising, the hard iteration cap terminating a tool loop that never stops requesting tools, bad-JSON tool arguments not crashing, and the API key being read only from the environment
- [x] No live API calls — the client is fully injected/mocked
- [x] `black --check` and `flake8 --max-line-length=127` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)