### PR TITLE
feat: implement guardrails - rate limits, spend kill-switch (#126)

### DIFF
--- a/projects/08-linkedin-avatar/avatar/guardrails.py
+++ b/projects/08-linkedin-avatar/avatar/guardrails.py
@@ -1,1 +1,217 @@
-"""Rate limits, input cap and daily spend kill-switch. Implemented in issue #126."""
+"""Rate limits, input cap and daily spend kill-switch.
+
+The one control that must be correct: an unmetered public LLM endpoint is an
+open invitation, and the daily budget kill-switch is the only thing standing
+between a bored visitor with a script and an unbounded bill. See
+docs/design.md §6. Every check here fails closed — an error inside the
+budget tracker blocks the call, it never waves it through.
+"""
+
+import logging
+import os
+import threading
+import time
+from datetime import datetime, timezone
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_MAX_INPUT_CHARS = 1500
+DEFAULT_SESSION_RATE_LIMIT = "20/hour"
+DEFAULT_IP_RATE_LIMIT = "40/day"
+DEFAULT_DAILY_BUDGET_USD = 2.00
+
+# Matches avatar.llm.DEFAULT_MODEL (#124) — duplicated rather than imported
+# so this module has no dependency on avatar.llm's tool-use loop.
+DEFAULT_MODEL_FOR_PRICING = "deepseek-v4-flash"
+
+_UNIT_SECONDS = {"hour": 3600, "day": 86400}
+
+# Verified against api-docs.deepseek.com/quick_start/pricing on 2026-08-30.
+# USD per 1M tokens, using the more expensive **peak** rate as the
+# conservative default (off-peak is half these figures) — prices move, so
+# re-check this page before trusting these numbers again.
+PRICE_TABLE_USD_PER_MTOK = {
+    "deepseek-v4-flash": {"cache_hit": 0.014, "cache_miss": 0.44, "output": 1.32},
+    "deepseek-v4-pro": {"cache_hit": 0.044, "cache_miss": 1.32, "output": 3.96},
+}
+
+INPUT_TOO_LONG_MESSAGE = (
+    "That's a bit long for this chat — could you shorten it and try again?"
+)
+RATE_LIMITED_MESSAGE = (
+    "You've reached the limit of questions for now — please try again a bit later, "
+    "or reach Steve directly via LinkedIn."
+)
+BUDGET_EXHAUSTED_MESSAGE = (
+    "My twin is resting for today — you can reach Steve directly via LinkedIn or email."
+)
+
+
+def _env_int(name, default):
+    raw = os.environ.get(name)
+    return default if raw is None else int(raw)
+
+
+def _env_float(name, default):
+    raw = os.environ.get(name)
+    return default if raw is None else float(raw)
+
+
+def _parse_rate_limit(spec):
+    """Parse "20/hour" or "40/day" into (max_events, window_seconds)."""
+    count_str, _, unit = spec.partition("/")
+    return int(count_str), _UNIT_SECONDS[unit]
+
+
+def estimate_cost_usd(usage, model=None):
+    """Estimate the USD cost of one response's usage figures against the
+    price table. `usage` is the dict avatar.llm.send_message returns."""
+    model = model or os.environ.get("AVATAR_MODEL", DEFAULT_MODEL_FOR_PRICING)
+    prices = PRICE_TABLE_USD_PER_MTOK.get(model)
+    if prices is None:
+        logger.warning(
+            "No price table entry for model %s; using %s",
+            model,
+            DEFAULT_MODEL_FOR_PRICING,
+        )
+        prices = PRICE_TABLE_USD_PER_MTOK[DEFAULT_MODEL_FOR_PRICING]
+
+    cache_hit_tokens = usage.get("cache_hit_tokens", 0)
+    cache_miss_tokens = usage.get("cache_miss_tokens", 0)
+    output_tokens = usage.get("output_tokens", 0)
+
+    cost = (
+        cache_hit_tokens * prices["cache_hit"]
+        + cache_miss_tokens * prices["cache_miss"]
+        + output_tokens * prices["output"]
+    ) / 1_000_000
+    return cost
+
+
+class _SlidingWindowLimiter:
+    """Thread-safe sliding-window rate limiter, held in process memory."""
+
+    def __init__(self, max_events, window_seconds, clock=time.time):
+        self.max_events = max_events
+        self.window_seconds = window_seconds
+        self._clock = clock
+        self._events = {}
+        self._lock = threading.Lock()
+
+    def allow(self, key):
+        now = self._clock()
+        cutoff = now - self.window_seconds
+        with self._lock:
+            events = [t for t in self._events.get(key, []) if t >= cutoff]
+            if len(events) >= self.max_events:
+                self._events[key] = events
+                return False
+            events.append(now)
+            self._events[key] = events
+            return True
+
+
+class GuardrailState:
+    """Holds the rate limiters and spend tracker for one running app.
+    Accepts explicit config and a clock so tests can drive both directly,
+    instead of going through environment variables and wall-clock time."""
+
+    def __init__(
+        self,
+        max_input_chars=None,
+        session_rate_limit=None,
+        ip_rate_limit=None,
+        daily_budget_usd=None,
+        clock=time.time,
+    ):
+        self.max_input_chars = (
+            _env_int("AVATAR_MAX_INPUT_CHARS", DEFAULT_MAX_INPUT_CHARS)
+            if max_input_chars is None
+            else max_input_chars
+        )
+        self.daily_budget_usd = (
+            _env_float("AVATAR_DAILY_BUDGET_USD", DEFAULT_DAILY_BUDGET_USD)
+            if daily_budget_usd is None
+            else daily_budget_usd
+        )
+
+        session_count, session_window = _parse_rate_limit(
+            session_rate_limit
+            or os.environ.get("AVATAR_SESSION_RATE_LIMIT", DEFAULT_SESSION_RATE_LIMIT)
+        )
+        ip_count, ip_window = _parse_rate_limit(
+            ip_rate_limit
+            or os.environ.get("AVATAR_IP_RATE_LIMIT", DEFAULT_IP_RATE_LIMIT)
+        )
+        self._session_limiter = _SlidingWindowLimiter(
+            session_count, session_window, clock=clock
+        )
+        self._ip_limiter = _SlidingWindowLimiter(ip_count, ip_window, clock=clock)
+
+        self._clock = clock
+        self._budget_lock = threading.Lock()
+        self._budget_day = None
+        self._spent_usd = 0.0
+
+    def _current_utc_day(self):
+        return datetime.fromtimestamp(self._clock(), tz=timezone.utc).date()
+
+    def _reset_budget_if_new_day(self):
+        today = self._current_utc_day()
+        if self._budget_day != today:
+            self._budget_day = today
+            self._spent_usd = 0.0
+
+    def is_budget_exhausted(self):
+        with self._budget_lock:
+            self._reset_budget_if_new_day()
+            return self._spent_usd >= self.daily_budget_usd
+
+    def record_usage(self, usage, model=None):
+        cost = estimate_cost_usd(usage, model)
+        with self._budget_lock:
+            self._reset_budget_if_new_day()
+            self._spent_usd += cost
+        return cost
+
+    def check_request(self, session_id, ip, message):
+        """Returns (allowed, refusal_message). refusal_message is None when allowed."""
+        if len(message) > self.max_input_chars:
+            return False, INPUT_TOO_LONG_MESSAGE
+
+        try:
+            budget_exhausted = self.is_budget_exhausted()
+        except Exception:
+            logger.exception("Budget tracker failed; failing closed")
+            budget_exhausted = True
+
+        if budget_exhausted:
+            return False, BUDGET_EXHAUSTED_MESSAGE
+
+        if not self._session_limiter.allow(session_id):
+            return False, RATE_LIMITED_MESSAGE
+        if not self._ip_limiter.allow(ip):
+            return False, RATE_LIMITED_MESSAGE
+
+        return True, None
+
+
+_default_state = None
+_default_state_lock = threading.Lock()
+
+
+def _get_default_state():
+    global _default_state
+    if _default_state is None:
+        with _default_state_lock:
+            if _default_state is None:
+                _default_state = GuardrailState()
+    return _default_state
+
+
+def check_request(session_id, ip, message):
+    return _get_default_state().check_request(session_id, ip, message)
+
+
+def record_usage(usage, model=None):
+    return _get_default_state().record_usage(usage, model)

--- a/projects/08-linkedin-avatar/tests/test_guardrails.py
+++ b/projects/08-linkedin-avatar/tests/test_guardrails.py
@@ -1,0 +1,184 @@
+"""Tests for avatar/guardrails.py."""
+
+import sys
+from pathlib import Path
+
+import pytest
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+from avatar import guardrails  # noqa: E402
+
+
+class FakeClock:
+    def __init__(self, start=1_000_000.0):
+        self.now = start
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += seconds
+
+
+def make_state(**overrides):
+    defaults = {
+        "max_input_chars": 1500,
+        "session_rate_limit": "20/hour",
+        "ip_rate_limit": "40/day",
+        "daily_budget_usd": 2.00,
+        "clock": FakeClock(),
+    }
+    defaults.update(overrides)
+    return guardrails.GuardrailState(**defaults), defaults["clock"]
+
+
+class TestInputLengthCap:
+    def test_oversized_message_rejected(self):
+        state, _ = make_state(max_input_chars=10)
+        allowed, reason = state.check_request("session-1", "1.2.3.4", "x" * 11)
+        assert allowed is False
+        assert reason == guardrails.INPUT_TOO_LONG_MESSAGE
+
+    def test_message_at_limit_is_allowed(self):
+        state, _ = make_state(max_input_chars=10)
+        allowed, reason = state.check_request("session-1", "1.2.3.4", "x" * 10)
+        assert allowed is True
+        assert reason is None
+
+
+class TestSlidingWindowRateLimits:
+    def test_session_limit_blocks_after_max_events(self):
+        state, clock = make_state(session_rate_limit="2/hour", ip_rate_limit="1000/day")
+        assert state.check_request("s1", "1.1.1.1", "hi")[0] is True
+        assert state.check_request("s1", "1.1.1.1", "hi")[0] is True
+        allowed, reason = state.check_request("s1", "1.1.1.1", "hi")
+        assert allowed is False
+        assert reason == guardrails.RATE_LIMITED_MESSAGE
+
+    def test_session_limit_releases_after_window_passes(self):
+        state, clock = make_state(session_rate_limit="1/hour", ip_rate_limit="1000/day")
+        assert state.check_request("s1", "1.1.1.1", "hi")[0] is True
+        assert state.check_request("s1", "1.1.1.1", "hi")[0] is False
+
+        clock.advance(3601)
+
+        assert state.check_request("s1", "1.1.1.1", "hi")[0] is True
+
+    def test_ip_limit_is_independent_of_session_limit(self):
+        state, clock = make_state(session_rate_limit="1000/hour", ip_rate_limit="1/day")
+        assert state.check_request("session-a", "9.9.9.9", "hi")[0] is True
+        # Different session, same IP: IP limit still blocks.
+        allowed, reason = state.check_request("session-b", "9.9.9.9", "hi")
+        assert allowed is False
+        assert reason == guardrails.RATE_LIMITED_MESSAGE
+
+    def test_different_sessions_have_independent_limits(self):
+        state, clock = make_state(session_rate_limit="1/hour", ip_rate_limit="1000/day")
+        assert state.check_request("session-a", "1.1.1.1", "hi")[0] is True
+        assert state.check_request("session-b", "2.2.2.2", "hi")[0] is True
+
+
+class TestEstimateCostUsd:
+    def test_known_usage_figures(self):
+        usage = {
+            "cache_hit_tokens": 1_000_000,
+            "cache_miss_tokens": 0,
+            "output_tokens": 0,
+        }
+        cost = guardrails.estimate_cost_usd(usage, model="deepseek-v4-flash")
+        assert cost == pytest.approx(0.014)
+
+    def test_cache_miss_and_output_priced_separately(self):
+        usage = {
+            "cache_hit_tokens": 0,
+            "cache_miss_tokens": 1_000_000,
+            "output_tokens": 1_000_000,
+        }
+        cost = guardrails.estimate_cost_usd(usage, model="deepseek-v4-flash")
+        assert cost == pytest.approx(0.44 + 1.32)
+
+    def test_unknown_model_falls_back_to_default(self):
+        usage = {
+            "cache_hit_tokens": 1_000_000,
+            "cache_miss_tokens": 0,
+            "output_tokens": 0,
+        }
+        cost = guardrails.estimate_cost_usd(usage, model="not-a-real-model")
+        default_cost = guardrails.estimate_cost_usd(
+            usage, model=guardrails.DEFAULT_MODEL_FOR_PRICING
+        )
+        assert cost == pytest.approx(default_cost)
+
+
+class TestBudgetKillSwitch:
+    def test_crossing_budget_switches_to_fixed_message(self):
+        state, clock = make_state(daily_budget_usd=0.01)
+        big_usage = {
+            "cache_hit_tokens": 0,
+            "cache_miss_tokens": 0,
+            "output_tokens": 1_000_000,
+        }
+
+        assert state.check_request("s1", "1.1.1.1", "hi")[0] is True
+        state.record_usage(big_usage, model="deepseek-v4-flash")
+
+        allowed, reason = state.check_request("s2", "2.2.2.2", "hi")
+        assert allowed is False
+        assert reason == guardrails.BUDGET_EXHAUSTED_MESSAGE
+
+    def test_budget_resets_on_utc_day_boundary(self):
+        state, clock = make_state(daily_budget_usd=0.01)
+        big_usage = {
+            "cache_hit_tokens": 0,
+            "cache_miss_tokens": 0,
+            "output_tokens": 1_000_000,
+        }
+        state.record_usage(big_usage, model="deepseek-v4-flash")
+        assert state.is_budget_exhausted() is True
+
+        clock.advance(86400)
+
+        assert state.is_budget_exhausted() is False
+
+    def test_budget_tracker_failure_fails_closed(self, monkeypatch):
+        state, clock = make_state()
+
+        def boom():
+            raise RuntimeError("budget tracker exploded")
+
+        monkeypatch.setattr(state, "is_budget_exhausted", boom)
+
+        allowed, reason = state.check_request("s1", "1.1.1.1", "hi")
+
+        assert allowed is False
+        assert reason == guardrails.BUDGET_EXHAUSTED_MESSAGE
+
+    def test_oversized_message_rejected_without_touching_budget(self):
+        state, clock = make_state(max_input_chars=5, daily_budget_usd=1000)
+        allowed, reason = state.check_request("s1", "1.1.1.1", "way too long")
+        assert allowed is False
+        assert reason == guardrails.INPUT_TOO_LONG_MESSAGE
+        # Budget untouched: still not exhausted at a huge budget.
+        assert state.is_budget_exhausted() is False
+
+
+class TestParseRateLimit:
+    def test_parses_hour_and_day(self):
+        assert guardrails._parse_rate_limit("20/hour") == (20, 3600)
+        assert guardrails._parse_rate_limit("40/day") == (40, 86400)
+
+
+class TestDefaultModuleFunctions:
+    def test_check_request_and_record_usage_use_a_shared_default_state(
+        self, monkeypatch
+    ):
+        monkeypatch.setattr(guardrails, "_default_state", None)
+        monkeypatch.setenv("AVATAR_DAILY_BUDGET_USD", "1000")
+        monkeypatch.setenv("AVATAR_SESSION_RATE_LIMIT", "1000/hour")
+        monkeypatch.setenv("AVATAR_IP_RATE_LIMIT", "1000/day")
+
+        allowed, reason = guardrails.check_request("s1", "1.1.1.1", "hi")
+
+        assert allowed is True
+        assert reason is None


### PR DESCRIPTION
## Summary
- `avatar/guardrails.py`: `check_request(session_id, ip, message)` → `(allowed, refusal_message)`, checking in order: input length cap, daily spend kill-switch, session rate limit, IP rate limit.
- `GuardrailState` holds the rate limiters and budget tracker with an injectable clock, so tests drive time directly instead of sleeping or mocking `time.time` globally. Module-level `check_request`/`record_usage` wrap a lazily-built default instance for production use.
- In-memory, thread-safe sliding-window limiters (no Redis, no external dependency) for `AVATAR_SESSION_RATE_LIMIT` (default `20/hour`) and `AVATAR_IP_RATE_LIMIT` (default `40/day`).
- `record_usage(usage, model=None)` prices a response's usage against a per-model table and accumulates it; the daily counter resets on a UTC day boundary.
- **Fails closed**: the budget check runs in a try/except inside `check_request` — any exception blocks the request rather than letting it through.

Fixes #126

## Pricing re-verified, not assumed
The issue explicitly says to check DeepSeek's current pricing rather than trust the remembered numbers baked into it. I re-fetched `api-docs.deepseek.com/quick_start/pricing` today (2026-08-30) — unchanged from the issue's figures, so the price table uses the same numbers, now with a fresh verification date in the comment.

Also removed a cross-module import I initially wrote (`from avatar.llm import DEFAULT_MODEL`) once I noticed this branch was cut from `main` before #124 merged — `llm.py` didn't have that constant yet on this branch. A guardrails PR shouldn't depend on merge order with another open PR, so `DEFAULT_MODEL_FOR_PRICING` is now a small duplicated local constant instead, with a comment noting what it should track.

## Test plan
- [x] `pytest projects/08-linkedin-avatar` — 108 passed, including: a fake clock driven across the session-limit window boundary and the UTC day boundary, session and IP limits verified independent of each other, cost arithmetic checked against known usage figures, crossing the budget switching to the fixed message, an oversized message rejected without touching the budget, an unknown model falling back to the default price table, and a forced exception inside the budget tracker still failing closed
- [x] `black --check` and `flake8 --max-line-length=127` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)