### PR TITLE
feat: build the Gradio chat UI and branding (#125)

### DIFF
--- a/projects/08-linkedin-avatar/app.py
+++ b/projects/08-linkedin-avatar/app.py
@@ -1,0 +1,71 @@
+"""Gradio ChatInterface for Steve's AI twin.
+
+Thin by design: the system prompt is built once at import time (never per
+request, or DeepSeek's prompt cache never gets a stable prefix — see
+docs/design.md §4), and each turn is just guardrails → the DeepSeek
+tool-use loop → guardrails again for spend accounting.
+"""
+
+import os
+
+import gradio as gr
+from dotenv import load_dotenv
+
+from avatar import context, guardrails, llm, styles
+
+load_dotenv()
+
+SYSTEM_PROMPT = context.build_system_prompt()
+
+
+def _client_ip(request):
+    if request is None or request.client is None:
+        return "unknown"
+    return request.client.host
+
+
+def _session_id(request):
+    if request is None or not request.session_hash:
+        return "unknown"
+    return request.session_hash
+
+
+def _to_conversation(history, message):
+    conversation = [{"role": m["role"], "content": m["content"]} for m in history]
+    conversation.append({"role": "user", "content": message})
+    return conversation
+
+
+def chat(message, history, request: gr.Request):
+    session_id = _session_id(request)
+    ip = _client_ip(request)
+
+    allowed, refusal = guardrails.check_request(session_id, ip, message)
+    if not allowed:
+        return refusal
+
+    conversation = _to_conversation(history, message)
+    reply, usage = llm.send_message(conversation, SYSTEM_PROMPT)
+    guardrails.record_usage(usage)
+    return reply
+
+
+def build_demo():
+    with gr.Blocks(title=styles.TITLE) as demo:
+        gr.Markdown(
+            f"# {styles.TITLE}\n\n{styles.DESCRIPTION}", elem_id="avatar-header"
+        )
+        gr.ChatInterface(
+            chat, examples=styles.EXAMPLE_QUESTIONS, run_examples_on_click=False
+        )
+        gr.Markdown(styles.FOOTER_MARKDOWN, elem_id="avatar-footer")
+    return demo
+
+
+if __name__ == "__main__":
+    port = os.environ.get("GRADIO_SERVER_PORT")
+    build_demo().launch(
+        server_name=os.environ.get("GRADIO_SERVER_NAME"),
+        server_port=int(port) if port else None,
+        css=styles.CSS,
+    )

--- a/projects/08-linkedin-avatar/avatar/styles.py
+++ b/projects/08-linkedin-avatar/avatar/styles.py
@@ -1,1 +1,88 @@
-"""CSS/JS/theme and example questions. Implemented in issue #125."""
+"""Copy and CSS for the Gradio chat UI. Structure adapted from
+ed-donner/agents `1_foundations/twin/styles.py`; palette and copy are our own.
+"""
+
+TITLE = "Steve Leonard — AI Twin"
+
+DESCRIPTION = (
+    "This is Steve's AI twin. Ask about his background or any project in his "
+    "GitHub — it reads both. It'll tell you when it doesn't know."
+)
+
+EXAMPLE_QUESTIONS = [
+    "What's his experience with Python and financial services?",
+    "Tell me about issue-worm.",
+    "Would he be a good fit for a staff engineering role?",
+    "How do I get in touch with him?",
+]
+
+FOOTER_MARKDOWN = (
+    "An email given to this chat is sent to Steve as a one-off notification — "
+    "not stored, not added to a list, not shared."
+)
+
+CSS = """
+:root {
+    --avatar-accent: #2f6fed;
+    --avatar-accent-dark: #7fa8ff;
+    --avatar-muted: #5b6270;
+    --avatar-muted-dark: #9aa2b1;
+}
+
+.gradio-container {
+    max-width: 760px !important;
+    margin: 0 auto !important;
+    font-family: -apple-system, "Segoe UI", Roboto, Helvetica, Arial, sans-serif !important;
+}
+
+#avatar-header {
+    text-align: center;
+    padding: 0.5rem 0 1rem 0;
+}
+
+#avatar-header h1 {
+    font-size: 1.5rem;
+    margin-bottom: 0.25rem;
+    color: var(--avatar-accent);
+}
+
+.dark #avatar-header h1 {
+    color: var(--avatar-accent-dark);
+}
+
+#avatar-header p {
+    color: var(--avatar-muted);
+    font-size: 0.95rem;
+    margin: 0;
+}
+
+.dark #avatar-header p {
+    color: var(--avatar-muted-dark);
+}
+
+#avatar-footer {
+    text-align: center;
+    font-size: 0.8rem;
+    color: var(--avatar-muted);
+    padding-top: 0.75rem;
+    margin-top: 0.5rem;
+    border-top: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.dark #avatar-footer {
+    color: var(--avatar-muted-dark);
+    border-top-color: rgba(255, 255, 255, 0.08);
+}
+
+@media (max-width: 480px) {
+    .gradio-container {
+        padding: 0.5rem !important;
+    }
+    #avatar-header h1 {
+        font-size: 1.2rem;
+    }
+    #avatar-header p {
+        font-size: 0.85rem;
+    }
+}
+"""

--- a/projects/08-linkedin-avatar/requirements.txt
+++ b/projects/08-linkedin-avatar/requirements.txt
@@ -1,5 +1,8 @@
 openai>=1.50.0
-gradio>=4.44.0
+# app.py relies on Gradio 6-only API shapes: css moved from Blocks() to
+# launch(), and ChatInterface history is dict-based only (no more tuples) —
+# do not loosen this below 6.0, the app breaks silently on an older release.
+gradio>=6.0.0
 pypdf>=4.3.0
 requests>=2.31.0
 python-dotenv>=1.0.1

--- a/projects/08-linkedin-avatar/tests/test_app.py
+++ b/projects/08-linkedin-avatar/tests/test_app.py
@@ -1,0 +1,93 @@
+"""Tests for app.py's chat orchestration logic. No live Gradio server, no
+live DeepSeek calls — guardrails and llm are monkeypatched."""
+
+import sys
+from pathlib import Path
+from types import SimpleNamespace
+
+sys.path.insert(0, str(Path(__file__).parent.parent))
+
+import app  # noqa: E402
+import gradio as gr  # noqa: E402
+
+
+def make_request(ip="1.2.3.4", session_hash="session-abc"):
+    return SimpleNamespace(client=SimpleNamespace(host=ip), session_hash=session_hash)
+
+
+class TestClientIpAndSessionId:
+    def test_client_ip_from_request(self):
+        assert app._client_ip(make_request(ip="9.9.9.9")) == "9.9.9.9"
+
+    def test_client_ip_missing_request_is_unknown(self):
+        assert app._client_ip(None) == "unknown"
+
+    def test_client_ip_missing_client_is_unknown(self):
+        assert app._client_ip(SimpleNamespace(client=None)) == "unknown"
+
+    def test_session_id_from_request(self):
+        assert app._session_id(make_request(session_hash="abc123")) == "abc123"
+
+    def test_session_id_missing_request_is_unknown(self):
+        assert app._session_id(None) == "unknown"
+
+    def test_session_id_empty_hash_is_unknown(self):
+        assert app._session_id(SimpleNamespace(session_hash="")) == "unknown"
+
+
+class TestToConversation:
+    def test_appends_message_to_history(self):
+        history = [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+        ]
+        conversation = app._to_conversation(history, "what's next?")
+        assert conversation == [
+            {"role": "user", "content": "hi"},
+            {"role": "assistant", "content": "hello"},
+            {"role": "user", "content": "what's next?"},
+        ]
+
+    def test_empty_history(self):
+        assert app._to_conversation([], "hi") == [{"role": "user", "content": "hi"}]
+
+
+class TestChat:
+    def test_refusal_short_circuits_before_calling_llm(self, monkeypatch):
+        monkeypatch.setattr(
+            app.guardrails, "check_request", lambda *a: (False, "rate limited")
+        )
+        called = {"llm": False}
+        monkeypatch.setattr(
+            app.llm,
+            "send_message",
+            lambda *a, **k: called.update(llm=True) or ("x", {}),
+        )
+
+        reply = app.chat("hi", [], make_request())
+
+        assert reply == "rate limited"
+        assert called["llm"] is False
+
+    def test_allowed_request_calls_llm_and_records_usage(self, monkeypatch):
+        monkeypatch.setattr(app.guardrails, "check_request", lambda *a: (True, None))
+        monkeypatch.setattr(
+            app.llm,
+            "send_message",
+            lambda conversation, system_prompt: ("a reply", {"output_tokens": 10}),
+        )
+        recorded = {}
+        monkeypatch.setattr(
+            app.guardrails, "record_usage", lambda usage: recorded.update(usage)
+        )
+
+        reply = app.chat("hi", [], make_request())
+
+        assert reply == "a reply"
+        assert recorded == {"output_tokens": 10}
+
+
+class TestBuildDemo:
+    def test_builds_without_error(self):
+        demo = app.build_demo()
+        assert isinstance(demo, gr.Blocks)


### PR DESCRIPTION
## Summary
- `app.py`: thin orchestration — builds the system prompt once at import time, then each chat turn goes through `guardrails.check_request` → `llm.send_message` → `guardrails.record_usage`. Session ID and client IP come from Gradio's injected `gr.Request`.
- `avatar/styles.py`: title, one-line pitch, four example questions (career, a specific project, role fit, getting in touch), the contact-data disclosure footer, and a custom CSS palette (light/dark aware, responsive down to mobile widths).
- `run_examples_on_click=False` — Gradio 6's `ChatInterface` defaults to auto-submitting an example on click, which isn't what the issue's "example prompts populate the input on click" asks for; found this by actually clicking one and watching it fire a live request.

Fixes #125

## Verified in a real browser, not just described
- Dark mode (the pane's default) and light mode (`resize_window` with `colorScheme: "light"`) both render correctly with the custom palette.
- 375px mobile width: example buttons stack to one column, text stays readable, nothing overflows.
- Desktop: the footer disclosure is visible without scrolling.
- Clicking an example populates the textbox without submitting (after the `run_examples_on_click=False` fix above — confirmed the before/after by screenshotting both).
- One click-through actually completed a full round trip against the live DeepSeek API (a real `DEEPSEEK_API_KEY` was present in the environment) and returned a real, knowledge-grounded answer about `issue-worm` pulled straight from `projects.md`'s curated note — good evidence the whole pipeline (context assembly → guardrails → DeepSeek tool-use loop → UI) works together, but worth flagging since it was a real, small API spend incurred during manual testing, not a mock.
- Fixed a Gradio 6 deprecation warning along the way: `css` moved from the `Blocks()` constructor to `.launch()`.

## What's deliberately not in this PR
The issue lists an avatar image asset under `site/` as a Files Affected item. I didn't add one — that needs an actual photo of Steve, which isn't something to fabricate. Everything else in the issue is implemented; the image is a small follow-up once a real photo is supplied.

## Test plan
- [x] `pytest projects/08-linkedin-avatar` — 134 passed, including the `chat()` orchestration (guardrail rejection short-circuits before calling the LLM; an allowed request calls the LLM and records usage), IP/session-ID extraction from `gr.Request` (including missing-request and missing-client edge cases), conversation history assembly, and that `build_demo()` constructs without error
- [x] Manual browser verification as described above (dark/light/mobile/example-click/live round trip)
- [x] `black --check` and `flake8 --max-line-length=127` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)