### PR TITLE
feat: nightly avatar knowledge-refresh GitHub Action (#121)

### DIFF
--- a/.github/workflows/avatar-knowledge-refresh.yml
+++ b/.github/workflows/avatar-knowledge-refresh.yml
@@ -1,0 +1,50 @@
+name: Avatar knowledge refresh
+
+on:
+  schedule:
+    - cron: "15 4 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+jobs:
+  refresh:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies
+        working-directory: projects/08-linkedin-avatar
+        run: pip install -r requirements.txt
+        shell: bash
+
+      - name: Rebuild GitHub knowledge snapshot
+        working-directory: projects/08-linkedin-avatar
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python build/build_github_snapshot.py --user leonarduk
+        shell: bash
+
+      # Scheduled runs never execute on a fork (GitHub disables cron
+      # triggers there), but a manual workflow_dispatch could — this keeps
+      # such a run green without attempting a push it has no business
+      # making.
+      - name: Commit and push if the snapshot changed
+        if: github.repository == 'leonarduk/ai-systems-lab'
+        run: |
+          set -euo pipefail
+          if git diff --quiet -- projects/08-linkedin-avatar/knowledge/github.json; then
+            echo "No changes to knowledge/github.json"
+            exit 0
+          fi
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add projects/08-linkedin-avatar/knowledge/github.json
+          git commit -m "chore: refresh avatar GitHub knowledge snapshot"
+          git push
+        shell: bash


### PR DESCRIPTION
## Summary
- New workflow `.github/workflows/avatar-knowledge-refresh.yml`: daily schedule (`15 4 * * *` UTC) + `workflow_dispatch`, modelled on the existing `octopus-agile-alert.yml` cron pattern.
- Reinstalls `projects/08-linkedin-avatar/requirements.txt`, reruns `build/build_github_snapshot.py --user leonarduk` with the built-in `GITHUB_TOKEN` for rate limits, then commits + pushes `knowledge/github.json` only if `git diff --quiet` says it actually changed.
- `contents: write` is the only permission granted (default `GITHUB_TOKEN` scope otherwise read-only); no third-party actions beyond `actions/checkout` and `actions/setup-python`.
- The commit/push step is guarded by `if: github.repository == 'leonarduk/ai-systems-lab'` — a manual `workflow_dispatch` run on a fork still succeeds, it just skips the push it has no business making.

Fixes #121

## Verified locally, not just written to spec
- **actionlint 1.7.12** (the exact version `workflow-lint.yml` pins) passes clean on this file and on the full `.github/workflows/*.yml` set — same invocation CI uses (`actionlint -color -shellcheck= .github/workflows/*.yml`).
- **Simulated the commit-and-push logic** against a disposable throwaway git repo (not this one) across three runs — unchanged file, then a real change, then unchanged again — and confirmed: no commit / commits / no commit. That's both of the issue's explicit success criteria (\"two consecutive runs with no upstream change produce no commit\") demonstrated directly, not just asserted.
- `build_github_snapshot.py`'s determinism (identical output for identical upstream data) was already covered by #120's own tests and a live run against the real API.

## Test plan
No test file for this issue (Files Affected is just the workflow YAML). Verification was actionlint + the local commit-logic simulation described above. Once merged, a manual `workflow_dispatch` run against the real repo is worth triggering once to confirm the full path end-to-end (checkout → install → rebuild → commit-if-changed) against live GitHub Actions, since that's the one thing that can't be simulated locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)