### PR TITLE
Stop Telegram bot token from leaking into logs on failure

### DIFF
--- a/projects/08-linkedin-avatar/avatar/tools.py
+++ b/projects/08-linkedin-avatar/avatar/tools.py
@@ -148,8 +148,12 @@ def _telegram_notify(title, message):
             timeout=10,
         )
         response.raise_for_status()
-    except requests.RequestException:
-        logger.exception("Telegram notification failed: %s", title)
+    except requests.RequestException as exc:
+        # Telegram's URL embeds the bot token (unlike Pushover's, which keeps
+        # it in the POST body) — logger.exception would print that URL, so
+        # log only the status code, never the exception object itself.
+        status = getattr(exc.response, "status_code", "no response")
+        logger.error("Telegram notification failed (status=%s): %s", status, title)
         return {"status": "failed", "detail": "notification could not be sent"}
 
     return {"status": "sent"}

--- a/projects/08-linkedin-avatar/tests/test_tools.py
+++ b/projects/08-linkedin-avatar/tests/test_tools.py
@@ -1,6 +1,7 @@
 """Tests for avatar/tools.py. No test performs a real network call."""
 
 import json
+import logging
 import sys
 from pathlib import Path
 
@@ -137,6 +138,35 @@ class TestTelegramNotify:
         result = tools._telegram_notify("title", "message")
 
         assert result["status"] == "failed"
+
+    def test_token_never_appears_in_logs_on_http_failure(self, monkeypatch, caplog):
+        # Telegram's URL embeds the token (.../bot<TOKEN>/sendMessage), unlike
+        # Pushover's fixed URL — a naive logger.exception would leak it into
+        # Render's logs, which is exactly what happened before this was fixed.
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "super-secret-token")
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "cid")
+        monkeypatch.setattr(tools.requests, "post", lambda *a, **k: FakeResponse(400))
+
+        with caplog.at_level(logging.ERROR):
+            result = tools._telegram_notify("title", "message")
+
+        assert result["status"] == "failed"
+        assert "super-secret-token" not in caplog.text
+
+    def test_token_never_appears_in_logs_on_connection_error(self, monkeypatch, caplog):
+        monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "super-secret-token")
+        monkeypatch.setenv("TELEGRAM_CHAT_ID", "cid")
+        monkeypatch.setattr(
+            tools.requests,
+            "post",
+            lambda *a, **k: (_ for _ in ()).throw(tools.requests.ConnectionError("no network")),
+        )
+
+        with caplog.at_level(logging.ERROR):
+            result = tools._telegram_notify("title", "message")
+
+        assert result["status"] == "failed"
+        assert "super-secret-token" not in caplog.text
 
 
 class TestNotifyFanOut:


### PR DESCRIPTION
## Summary
Found while verifying the Telegram notification channel added in #190 (relates to #130): Telegram's API embeds the bot token in the URL itself (`.../bot<TOKEN>/sendMessage`), unlike Pushover's fixed URL with the token in the POST body. `logger.exception` logged the full exception object, which includes that URL — so a failed send wrote the live token straight into Render's logs. Confirmed happening in production logs during testing just now.

- `_telegram_notify` now logs only the HTTP status code on failure, never the exception object
- Added regression tests asserting the token can never appear in log output on either an HTTP failure or a connection error
- No behavior change to the public `record_contact`/`record_unknown_question`/`_notify` contract — only what gets logged on the failure path

Relates to #130.

## Test plan
- [x] `pytest projects/08-linkedin-avatar/tests/test_tools.py` — 27/27 passing, including two new leak-regression tests
- [ ] Steve is regenerating the exposed bot token in Telegram and will re-verify a real send once this is deployed

🤖 Generated with [Claude Code](https://claude.com/claude-code)