### PR TITLE
Keep-warm ping and LinkedIn wiring (#131, #132)

### DIFF
--- a/.github/workflows/avatar-keep-warm.yml
+++ b/.github/workflows/avatar-keep-warm.yml
@@ -1,0 +1,43 @@
+name: Avatar keep-warm ping
+
+on:
+  schedule:
+    # Every ~14 minutes, 07:00-22:59 UTC. Render's free tier sleeps after 15
+    # minutes idle, so a 14-minute cadence keeps the app continuously warm
+    # through this window instead of cold-starting on a visitor's request.
+    #
+    # Instance-hours (see docs/design.md §9 in projects/08-linkedin-avatar):
+    # Render gives 750 instance-hours/month, shared across the whole
+    # workspace, and a sleeping service uses none. This 16h/day window costs
+    # roughly 16 * 31 = 496 instance-hours/month — well inside the allowance
+    # even with a second free service sharing it. Pinging a single service
+    # 24/7 (744h in a 31-day month) would also technically fit, with about
+    # six hours of headroom — the partial window is a deliberate choice to
+    # keep more of that headroom, not an arithmetic necessity. Widening to
+    # 24/7 is a legitimate call if this ever becomes the only free service
+    # running and always-warm is wanted — just re-check the current
+    # allowance first.
+    - cron: "*/14 7-22 * * *"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  ping:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ping the app (retry once, never fail the run on a transient miss)
+        run: |
+          set -uo pipefail
+          url="https://ai-systems-lab-s8gy.onrender.com"
+          attempt() { curl -sSf --max-time 60 "$url" -o /dev/null; }
+
+          if attempt; then
+            echo "Ping succeeded"
+          elif attempt; then
+            echo "Retry succeeded"
+          else
+            echo "::warning::Both keep-warm pings failed — app may be down or slow to wake"
+          fi
+        shell: bash

--- a/README.md
+++ b/README.md
@@ -44,6 +44,12 @@ Zero-dependency scheduled job that checks tomorrow's half-hourly Octopus Agile e
 
 **Tech stack:** Python (stdlib only), GitHub Actions (daily cron)
 
+### [LinkedIn Avatar](./projects/08-linkedin-avatar/)
+An AI twin that talks to visitors about my career and my GitHub projects — one link, dropped into the Featured section of my LinkedIn profile. Grounded in a redacted CV plus a nightly-refreshed snapshot of this org's repos, it hands contact requests off via Telegram and stays within a hard daily spend cap.
+
+**Status:** Live — [chat with it](https://ai-systems-lab-s8gy.onrender.com) or see the [landing page](https://leonarduk.github.io/ai-systems-lab/projects/08-linkedin-avatar/site/)
+**Tech stack:** Python, Gradio, DeepSeek API, GitHub REST API, Telegram, Render, GitHub Pages
+
 ### Prompt Engineering Patterns
 Structured prompts for code review, systems analysis, and log extraction with measurable outcomes — a systematic approach to LLM interaction design and output structuring.
 
@@ -117,7 +123,8 @@ ai-systems-lab/
 │   ├── 04-gmail-inbox-labeler/
 │   ├── 05-llm-cost-comparison/
 │   ├── 05-prize-draw-orchestrator/
-│   └── 06-octopus-agile-alert/
+│   ├── 06-octopus-agile-alert/
+│   └── 08-linkedin-avatar/
 ├── prompts/               # Prompt engineering examples
 ├── docs/                  # Architecture diagrams, guides, banner
 ├── examples/               # Reference implementations
@@ -125,4 +132,4 @@ ai-systems-lab/
 
 ---
 
-*Last updated: August 22, 2026*
+*Last updated: August 30, 2026*

--- a/projects/08-linkedin-avatar/README.md
+++ b/projects/08-linkedin-avatar/README.md
@@ -8,7 +8,7 @@ the Featured section of my LinkedIn profile.
 
 **Live URLs**:
 - App: [ai-systems-lab-s8gy.onrender.com](https://ai-systems-lab-s8gy.onrender.com)
-- Landing page: *TODO — GitHub Pages URL*
+- Landing page: [leonarduk.github.io/ai-systems-lab/projects/08-linkedin-avatar/site/](https://leonarduk.github.io/ai-systems-lab/projects/08-linkedin-avatar/site/)
 
 See [`docs/deployment.md`](./docs/deployment.md) for exactly how to deploy, rotate a key, check
 logs, or take it down in a hurry.
@@ -24,7 +24,8 @@ it doesn't know something, it says so and records the question rather than inven
 
 Its knowledge is three plain-text files baked into a cached system prompt: a hand-written
 `summary.txt` for voice, a `profile.md` derived from my LinkedIn PDF export with contact details
-redacted, and a `github.json` snapshot of my public repos refreshed nightly by a GitHub Action.
+redacted, and a `github.json` snapshot of my public repos refreshed nightly by a GitHub Action — so
+a new repo anywhere in this org shows up in what the twin knows within a day, no redeploy needed.
 There are three tools — record a contact, record an unanswerable question, look up one project in
 detail — and no database.
 

--- a/projects/08-linkedin-avatar/docs/linkedin-setup.md
+++ b/projects/08-linkedin-avatar/docs/linkedin-setup.md
@@ -1,0 +1,55 @@
+# Putting it on LinkedIn
+
+The checklist for turning the deployed app into an actual link on
+[linkedin.com/in/leonarduk](https://www.linkedin.com/in/leonarduk) — the "just tell me what to
+click" version, same style as [`deployment.md`](./deployment.md).
+
+Landing page URL (what LinkedIn should link to, never the raw Render URL):
+`https://leonarduk.github.io/ai-systems-lab/projects/08-linkedin-avatar/site/`
+
+---
+
+## 1. Featured section
+
+1. On your profile, click **Add profile section** (or the **+** on an existing Featured section) →
+   **Recommended** → **Featured** → **Add a link**.
+2. Paste the landing page URL above and give it a moment — LinkedIn fetches the preview from the
+   page's Open Graph tags automatically, so the title ("Steve Leonard — AI Twin"), description and
+   image should populate on their own. `site/og-image.png` was already built for exactly this; there's
+   nothing extra to design or upload.
+3. If the preview comes back blank or shows something stale, LinkedIn caches URL scrapes. Run the
+   URL through the [LinkedIn Post Inspector](https://www.linkedin.com/post-inspector/) first to force
+   a fresh fetch, then try adding it to Featured again.
+4. Save.
+
+## 2. Website field (contact info)
+
+1. On your profile, open **Contact info** (below your name/headline) → the edit (pencil) icon.
+2. Under **Website**, click **Add website** → type **Portfolio** (or **Other** if Portfolio isn't
+   offered) → paste the landing page URL above → **Save**.
+
+## 3. Launch post (draft)
+
+Edit freely — this is a starting point, not a script.
+
+> I built an AI version of myself that can talk about my career and my GitHub projects. Try it: [landing page link]
+>
+> A few things I wanted to get right:
+>
+> - It only answers from what's actually true — a redacted copy of my CV and a live snapshot of my public repos, refreshed nightly. If it doesn't know something, it says so instead of making it up.
+> - It's cheap to run. I picked DeepSeek over a bigger-name API specifically so a demo page doesn't cost real money to leave running — and then designed around that constraint on purpose.
+> - It has real guardrails: rate limits, an input cap, and a hard daily spend kill-switch. A public endpoint with an API key behind it needs those from day one, not as an afterthought.
+> - Want to get in touch after chatting with it? Tell it, and your details come straight to me.
+>
+> It's part of a bigger repo where I'm building production-quality AI tooling and writing up what I learn, mistakes included: [repo link — https://github.com/leonarduk/ai-systems-lab]
+>
+> Happy to talk through how any of it works.
+
+## 4. Verify
+
+Once both are live, reload your public profile (or use an incognito window — Featured content can
+render differently to you than to a visitor) and confirm:
+
+- The Featured card shows the image/title/description, not a bare link
+- Clicking it lands on the landing page, and "Start chatting" reaches a warm app
+- The Website field under Contact info opens the same URL


### PR DESCRIPTION
## Summary
- `.github/workflows/avatar-keep-warm.yml` pings the Render app every ~14 minutes during 07:00-22:59 UTC to keep it from sleeping. Retries once on failure, only ever logs a `::warning::` rather than failing the run. Instance-hours arithmetic (from `docs/design.md` §9) is documented in the workflow comment; validated clean with `actionlint`.
- Root `README.md`: new LinkedIn Avatar entry under "What I'm Building" (status, live links, tech stack) matching the existing entries' shape, plus the repository-structure block and "Last updated" line.
- `projects/08-linkedin-avatar/README.md`: fills in the landing-page URL (was a TODO placeholder — GitHub Pages is now confirmed live) and adds a note that a new repo anywhere in the org shows up in the twin's knowledge within a day via the nightly refresh Action.
- New `projects/08-linkedin-avatar/docs/linkedin-setup.md`: Featured-section steps (the page's existing OG tags populate the preview automatically, no extra image work needed), the Website contact-info field, and a draft launch post.

Closes #131. Closes #132.

## Test plan
- [x] `actionlint -color .github/workflows/*.yml` — clean
- [x] Landing page's OG tags manually verified live and correct (done while closing out #130)
- [ ] Steve to actually add the Featured link and Website field on LinkedIn per the new setup doc — that part is inherently manual (LinkedIn has no API for it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)