### PR TITLE
Sharper example question, sync launch post draft

### DIFF
--- a/projects/08-linkedin-avatar/avatar/styles.py
+++ b/projects/08-linkedin-avatar/avatar/styles.py
@@ -10,7 +10,7 @@ DESCRIPTION = (
 )
 
 EXAMPLE_QUESTIONS = [
-    "What's his experience with Python and financial services?",
+    "What AI system did he build at JPMorgan?",
     "Tell me about issue-worm.",
     "Would he be a good fit for a staff engineering role?",
     "How do I get in touch with him?",

--- a/projects/08-linkedin-avatar/docs/linkedin-setup.md
+++ b/projects/08-linkedin-avatar/docs/linkedin-setup.md
@@ -43,16 +43,16 @@ the live app or landing page.
 
 Edit freely — this is a starting point, not a script.
 
-> I built an AI version of myself that can talk about my career and my GitHub projects. Try it: [landing page link]
+> I built an AI version of myself that can talk about my career and my GitHub projects. Try it: https://leonarduk.github.io/ai-systems-lab/projects/08-linkedin-avatar/site
 >
 > A few things I wanted to get right:
 >
 > - It only answers from what's actually true — a redacted copy of my CV and a live snapshot of my public repos, refreshed nightly. If it doesn't know something, it says so instead of making it up.
 > - It's cheap to run. I picked DeepSeek over a bigger-name API specifically so a demo page doesn't cost real money to leave running — and then designed around that constraint on purpose.
 > - It has real guardrails: rate limits, an input cap, and a hard daily spend kill-switch. A public endpoint with an API key behind it needs those from day one, not as an afterthought.
-> - Want to get in touch after chatting with it? Tell it, and your details come straight to me.
+> - Want to get in touch after chatting with it? Tell it, and your details come straight to me as a Telegram message.
 >
-> It's part of a bigger repo where I'm building production-quality AI tooling and writing up what I learn, mistakes included: [repo link — https://github.com/leonarduk/ai-systems-lab]
+> It's part of a bigger effort where I'm building production-quality AI tooling and writing up what I learn, mistakes included.
 >
 > Happy to talk through how any of it works.
 

--- a/projects/08-linkedin-avatar/site/index.html
+++ b/projects/08-linkedin-avatar/site/index.html
@@ -183,7 +183,7 @@
   </p>
 
   <ul class="examples">
-    <li>"What's his experience with Python and financial services?"</li>
+    <li>"What AI system did he build at JPMorgan?"</li>
     <li>"Tell me about issue-worm."</li>
     <li>"How do I get in touch with him?"</li>
   </ul>


### PR DESCRIPTION
## Summary
- Landing page and chat UI both opened with a generic "What's his experience with Python and financial services?" — swapped for "What AI system did he build at JPMorgan?" on both, which now that `profile.md` has the real MCP/NL-to-SQL project in detail, shows the actual differentiator rather than just confirming a skill match.
- `docs/linkedin-setup.md`'s launch post draft synced to the final wording Steve's actually posting (real landing page URL, explicit Telegram mention, "bigger effort" instead of a dangling repo link).

Relates to #132.

## Test plan
- [x] `pytest` — 96 passed (same 2 pre-existing, unrelated collection errors as prior PRs)
- [x] No test coverage depends on the exact example-question or launch-post text (confirmed via grep)

🤖 Generated with [Claude Code](https://claude.com/claude-code)