### PR TITLE
Fix AI twin profile: credit full build of JPMorgan chatbot + MCP server

### DIFF
--- a/projects/08-linkedin-avatar/knowledge/profile.md
+++ b/projects/08-linkedin-avatar/knowledge/profile.md
@@ -31,14 +31,13 @@ Senior software engineer with 20+ years in financial services,
 primarily building Java-based systems — distributed services, risk
 platforms, and high-throughput data processing — with growing
 depth in applied AI and LLM integration.Most recently at JPMorgan,
-I designed and delivered a natural-language query system over
-financial databases: an LLM-powered internal chatbot with enterprise
-authentication that exposed MCP tool servers and generated SQL
-against a Sybase IQ warehouse, built on Java/Spring Boot services.
-I built the retrieval and context-guidance layer that kept SQL
-generation safe, auditable, and aligned with internal data controls
-— the kind of work where solid backend engineering and modern AI
-capabilities reinforce each other, rather than AI being bolted on.My
+I designed and built a natural-language query system over
+financial databases end to end: an LLM-powered internal chatbot with
+enterprise authentication, backed by a three-tool MCP server I built
+for discovery, context retrieval and auditable SQL generation against
+a Sybase IQ warehouse, on Java/Spring Boot services — the kind of work
+where solid backend engineering and modern AI capabilities reinforce
+each other, rather than AI being bolted on.My
 background spans Swiss Re, Credit Suisse, Morgan Stanley, and
 JPMorgan across risk platforms, distributed services, and cloud
 infrastructure — mostly Java, with Python where it's the right tool for


### PR DESCRIPTION
Fixes #204

## Summary

The AI twin chatbot's "What AI system did he build at JPMorgan?" answer described Steve's personal contribution as just "the retrieval and context-guidance layer," implying the chatbot and MCP server themselves were someone else's work. That's wrong — Steve built the whole thing.

- `projects/08-linkedin-avatar/knowledge/profile.md`'s Summary section said "I built the retrieval and context-guidance layer that kept SQL generation safe..." — narrowing his credit to one sub-component.
- The Experience section immediately below it already said he built the full three-tool MCP server and chatbot ("Built an LLM-driven chatbot on the firm's LLMSuite platform... integrating enterprise SSO and a three-tool MCP server for discovery, context retrieval and auditable SQL generation"), and `projects.md` also already credits him with "the MCP tool server architecture I built at JPMorgan Chase."

This brings the Summary section in line with the rest of the profile: Steve designed and built the natural-language query system end to end — the chatbot and the three-tool MCP server behind it.

## Test plan

- [x] Confirmed no other knowledge files (`summary.txt`, `projects.md`, `github.json`) or the app's static site text repeat the downplayed framing.
- Content-only change to a knowledge markdown file consumed verbatim by `avatar/context.py`; no code paths affected, so no test suite run was needed.